### PR TITLE
fix(UI): missing role name in `Key Participant` card

### DIFF
--- a/src/firefighter/incidents/templates/pages/incident_detail.html
+++ b/src/firefighter/incidents/templates/pages/incident_detail.html
@@ -189,7 +189,7 @@
           {% fill "card_content" %}
             {% for role in incident.roles_set.all %}
               <span class="ff-tooltip">
-                {% include "../layouts/partials/user_card.html" with user=role.user title=role.role.name only %}
+                {% include "../layouts/partials/user_card.html" with user=role.user title=role.role_type.name only %}
                 {% include "../layouts/partials/user_tooltip.html" with user=role.user only %}
               </span>
             {% endfor %}


### PR DESCRIPTION
Role name was always defaulting to `FireFighter`