### PR TITLE
feat(slack): advertise when others are creating an incident

### DIFF
--- a/src/firefighter/incidents/forms/create_incident.py
+++ b/src/firefighter/incidents/forms/create_incident.py
@@ -79,6 +79,7 @@ class CreateIncidentForm(CreateIncidentFormBase):
         self,
         creator: User,
         impacts_data: dict[str, ImpactLevel],
+        source_channel: Any,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -89,4 +90,5 @@ class CreateIncidentForm(CreateIncidentFormBase):
         create_incident_conversation.send(
             "create_incident_form",
             incident=incident,
+            source_channel=source_channel
         )

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -1156,7 +1156,7 @@ class SlackMessageIncidentOpeningWarning(SlackMessageSurface):
         super().__init__()
 
     def get_text(self) -> str:
-        return f"<@{self.channel["user_id"]}> is opening an incident at the moment. Please wait before creating one. :ballot_box_with_ballot:"
+        return f"<@{self.channel['user_id']}> is opening an incident at the moment. Please wait before creating one. :ballot_box_with_ballot:"
 
 
 class SlackMessageIncidentCreationRedirection(SlackMessageSurface):

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -1146,3 +1146,14 @@ class SlackMessageIncidentDowngradeHint(SlackMessageSurface):
 
     def get_text(self) -> str:
         return f"Incident #{self.incident.id} might not need an incident channel, as it is {self.incident.priority.name}."
+
+
+class SlackMessageIncidentCreationWarning(SlackMessageSurface):
+    id = "ff_incident_creation_warning"
+
+    def __init__(self, channel: Any):
+        self.channel = channel
+        super().__init__()
+
+    def get_text(self) -> str:
+        return f"<@{self.channel["user_id"]}> is opening an incident at the moment. Please wait before creating one. :ballot_box_with_ballot:"

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -1148,8 +1148,8 @@ class SlackMessageIncidentDowngradeHint(SlackMessageSurface):
         return f"Incident #{self.incident.id} might not need an incident channel, as it is {self.incident.priority.name}."
 
 
-class SlackMessageIncidentCreationWarning(SlackMessageSurface):
-    id = "ff_incident_creation_warning"
+class SlackMessageIncidentOpeningWarning(SlackMessageSurface):
+    id = "ff_incident_opening_warning"
 
     def __init__(self, channel: Any):
         self.channel = channel
@@ -1157,3 +1157,14 @@ class SlackMessageIncidentCreationWarning(SlackMessageSurface):
 
     def get_text(self) -> str:
         return f"<@{self.channel["user_id"]}> is opening an incident at the moment. Please wait before creating one. :ballot_box_with_ballot:"
+
+
+class SlackMessageIncidentCreationRedirection(SlackMessageSurface):
+    id = "ff_incident_creation_redirection"
+
+    def __init__(self, channel: Any):
+        self.channel = channel
+        super().__init__()
+
+    def get_text(self) -> str:
+        return f"A new incident has just been created in #{self.channel.name}. You can go there to follow the incident."

--- a/src/firefighter/slack/signals/create_incident_conversation.py
+++ b/src/firefighter/slack/signals/create_incident_conversation.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 @receiver(signal=create_incident_conversation)
 def create_incident_slack_conversation(
     incident: Incident,
-    source_channel: IncidentChannel,
+    source_channel: Any,
     *_args: Any,
     **_kwargs: Any,
 ) -> int | None:
@@ -46,7 +46,7 @@ def create_incident_slack_conversation(
 
     Args:
         incident (Incident): The incident to open. It should be saved before calling this function, and have its first incident update created.
-        source_channel (IncidentChannel): The channel from which the incident was opened, used for sending notifications and updates.
+        source_channel (Any): The channel from which the incident was opened, used for sending notifications and updates.
 
     Kwargs:
         jira_extra_fields (dict): Optional dictionary of customer/seller fields for Jira ticket

--- a/src/firefighter/slack/signals/create_incident_conversation.py
+++ b/src/firefighter/slack/signals/create_incident_conversation.py
@@ -15,6 +15,7 @@ from slack_sdk.errors import SlackApiError
 from firefighter.incidents.signals import create_incident_conversation
 from firefighter.slack.messages.slack_messages import (
     SlackMessageDeployWarning,
+    SlackMessageIncidentCreationRedirection,
     SlackMessageIncidentDeclaredAnnouncement,
     SlackMessageIncidentDeclaredAnnouncementGeneral,
 )
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 @receiver(signal=create_incident_conversation)
 def create_incident_slack_conversation(
     incident: Incident,
+    source_channel: IncidentChannel,
     *_args: Any,
     **_kwargs: Any,
 ) -> int | None:
@@ -44,6 +46,7 @@ def create_incident_slack_conversation(
 
     Args:
         incident (Incident): The incident to open. It should be saved before calling this function, and have its first incident update created.
+        source_channel (IncidentChannel): The channel from which the incident was opened, used for sending notifications and updates.
 
     Kwargs:
         jira_extra_fields (dict): Optional dictionary of customer/seller fields for Jira ticket
@@ -138,4 +141,14 @@ def create_incident_slack_conversation(
         channel=channel,
         jira_extra_fields=jira_extra_fields,
     )
+
+    notify_incident_created(channel=channel, source_channel=source_channel)
+
     return None
+
+
+def notify_incident_created(channel: IncidentChannel, source_channel: IncidentChannel) -> None:
+    """Notify the Slack channel that the incident has been created."""
+    message = SlackMessageIncidentCreationRedirection(channel)
+
+    source_channel.send_message_and_save(message)

--- a/src/firefighter/slack/views/modals/open.py
+++ b/src/firefighter/slack/views/modals/open.py
@@ -26,6 +26,7 @@ from firefighter.incidents.forms.select_impact import SelectImpactForm
 from firefighter.incidents.models.impact import ImpactType
 from firefighter.incidents.models.incident import Incident
 from firefighter.incidents.models.priority import Priority
+from firefighter.slack.models.conversation import Conversation
 from firefighter.slack.slack_app import SlackApp
 from firefighter.slack.slack_incident_context import get_user_from_context
 from firefighter.slack.views.modals.base_modal.base import SlackModal
@@ -70,6 +71,23 @@ class OpenModal(SlackModal):
     open_action: str = "open_incident"
     open_shortcut = "open_incident"
     callback_id: str = "incident_open"
+
+    def open_modal_aio(self, ack: Ack, body: dict[str, Any], **kwargs: Any) -> None:
+        super().open_modal_aio(ack, body, **kwargs)
+        from firefighter.slack.messages.slack_messages import (  # noqa: PLC0415
+            SlackMessageIncidentCreationWarning,
+        )
+
+        warning_message = SlackMessageIncidentCreationWarning(channel=body)
+
+        channel, _ = Conversation.objects.get_or_create(
+            channel_id=body["channel_id"],
+                defaults={
+                    "name": body["channel_name"],
+                },
+        )
+
+        channel.send_message_and_save(warning_message)
 
     def build_modal_fn(
         self, open_incident_context: OpeningData | None = None, user: User | None = None

--- a/src/firefighter/slack/views/modals/open.py
+++ b/src/firefighter/slack/views/modals/open.py
@@ -75,10 +75,10 @@ class OpenModal(SlackModal):
     def open_modal_aio(self, ack: Ack, body: dict[str, Any], **kwargs: Any) -> None:
         super().open_modal_aio(ack, body, **kwargs)
         from firefighter.slack.messages.slack_messages import (  # noqa: PLC0415
-            SlackMessageIncidentCreationWarning,
+            SlackMessageIncidentOpeningWarning,
         )
 
-        warning_message = SlackMessageIncidentCreationWarning(channel=body)
+        warning_message = SlackMessageIncidentOpeningWarning(channel=body)
 
         channel, _ = Conversation.objects.get_or_create(
             channel_id=body["channel_id"],
@@ -86,6 +86,8 @@ class OpenModal(SlackModal):
                     "name": body["channel_name"],
                 },
         )
+
+        self.source_channel = channel
 
         channel.send_message_and_save(warning_message)
 
@@ -166,6 +168,7 @@ class OpenModal(SlackModal):
             *set_details_blocks,
             *done_review_blocks,
         ]
+
         return View(
             type="modal",
             title="Create an incident"[:24],

--- a/src/firefighter/slack/views/modals/open.py
+++ b/src/firefighter/slack/views/modals/open.py
@@ -74,7 +74,7 @@ class OpenModal(SlackModal):
 
     def open_modal_aio(self, ack: Ack, body: dict[str, Any], **kwargs: Any) -> None:
         super().open_modal_aio(ack, body, **kwargs)
-        from firefighter.slack.messages.slack_messages import (  # noqa: PLC0415
+        from firefighter.slack.messages.slack_messages import (
             SlackMessageIncidentOpeningWarning,
         )
 


### PR DESCRIPTION
# Implement Notifications for Incident Opening and Creation Links in Slack

## Description

This PR introduces two new message classes for handling notifications related to incident management in the Slack application. The first class provides a warning when a user is in the process of opening an incident, while the second class informs users when a new incident has been created.

## Changes Made
 ✅ Created SlackMessageIncidentOpeningWarning to notify users when an incident is being opened.
 ✅ Created SlackMessageIncidentCreationRedirection to inform users of a new incident creation.
 ✅ Updated IDs for both classes to ensure they are distinct and descriptive.

## Motivation and Context
These changes are important to improve user experience by preventing multiple incident creations and guiding users to newly created incidents. By providing timely notifications, we can enhance communication and efficiency within the team.

## How to Test

1. Trigger the /open command in a Slack channel to test the SlackMessageIncidentOpeningWarning.
2. Verify that the warning message appears correctly and mentions the user who initiated the action.
3. Create a new incident and ensure that the SlackMessageIncidentCreationRedirection message is sent to the channel.
4. Check that the message correctly refers to the newly created incident and provides accurate channel information.

## Checklist
- [X] I have tested my changes
- [X] My code follows the style guidelines of this project
