### PR TITLE
feat(slack): add /critical shortcut to create incident more efficiently

### DIFF
--- a/src/firefighter/incidents/forms/create_incident.py
+++ b/src/firefighter/incidents/forms/create_incident.py
@@ -78,14 +78,16 @@ class CreateIncidentForm(CreateIncidentFormBase):
     def trigger_incident_workflow(
         self,
         creator: User,
-        impacts_data: dict[str, ImpactLevel],
+        impacts_data: dict[str, ImpactLevel] | None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         incident = Incident.objects.declare(created_by=creator, **self.cleaned_data)
-        impacts_form = SelectImpactForm(impacts_data)
 
-        impacts_form.save(incident=incident)
+        if impacts_data is not None:
+            impacts_form = SelectImpactForm(impacts_data)
+            impacts_form.save(incident=incident)
+
         create_incident_conversation.send(
             "create_incident_form",
             incident=incident,

--- a/src/firefighter/slack/management/commands/generate_manifest.py
+++ b/src/firefighter/slack/management/commands/generate_manifest.py
@@ -120,7 +120,7 @@ def get_manifest(
                     "command": command,
                     "url": f"{public_base_url}/api/v2/firefighter/slack/incident/",
                     "description": "Manage Incidents 🚨",
-                    "usage_hint": "[open|update|close|status|help]",
+                    "usage_hint": "[open|critical|update|close|status|help]",
                     "should_escape": False,
                 }
                 for command in [main_command, *command_aliases]

--- a/src/firefighter/slack/views/events/commands.py
+++ b/src/firefighter/slack/views/events/commands.py
@@ -15,6 +15,7 @@ from firefighter.slack.slack_templating import (
 )
 from firefighter.slack.views.modals import (
     modal_close,
+    modal_critical,
     modal_dowgrade_workflow,
     modal_edit,
     modal_open,
@@ -111,6 +112,8 @@ def manage_incident(ack: Ack, respond: Respond, body: dict[str, Any]) -> None:
         modal_edit.open_modal_aio(ack, body)
     elif command == "close":
         modal_close.open_modal_aio(ack=ack, body=body)
+    elif command == "critical":
+        modal_critical.open_modal_aio(ack=ack, body=body)
     elif command == "status":
         modal_status.open_modal_aio(ack=ack, body=body)
     elif command in {"oncall", "on-call"}:

--- a/src/firefighter/slack/views/modals/__init__.py
+++ b/src/firefighter/slack/views/modals/__init__.py
@@ -7,6 +7,7 @@ from firefighter.slack.views.modals.closure_reason import (
     ClosureReasonModal,
     modal_closure_reason,
 )
+from firefighter.slack.views.modals.critical import CriticalModal, modal_critical
 from firefighter.slack.views.modals.downgrade_workflow import (
     DowngradeWorkflowModal,
     modal_dowgrade_workflow,
@@ -52,4 +53,5 @@ selectable_modals: list[type[SlackModal]] = [
     StatusModal,
     SendSosModal,
     DowngradeWorkflowModal,
+    CriticalModal
 ]

--- a/src/firefighter/slack/views/modals/critical.py
+++ b/src/firefighter/slack/views/modals/critical.py
@@ -8,7 +8,9 @@ from slack_sdk.models.blocks.blocks import SectionBlock
 from slack_sdk.models.views import View
 
 from firefighter.incidents.forms.create_incident import CreateIncidentForm
+from firefighter.incidents.models.incident_membership import IncidentMembership
 from firefighter.slack.slack_app import SlackApp
+from firefighter.slack.utils import respond
 from firefighter.slack.views.modals.base_modal.base import ModalForm
 
 if TYPE_CHECKING:
@@ -91,6 +93,11 @@ class CriticalModal(ModalForm[CriticalFormSlack]):
     def handle_modal_fn(  # type: ignore
         self, ack: Ack, body: dict[str, Any], user: User
     ) -> None :
+        if not self.is_user_member_of_incident(user):
+            ack()
+            respond(body, text=":x: You must be linked to an incident to use this command.")
+            return
+
         slack_form = self.handle_form_errors(
             ack, body, forms_kwargs={},
         )
@@ -115,6 +122,9 @@ class CriticalModal(ModalForm[CriticalFormSlack]):
         if len(form.cleaned_data) == 0:
             logger.warning("Form is empty, no data captured.")
             return
+
+    def is_user_member_of_incident(self, user: User) -> bool:
+        return IncidentMembership.objects.filter(user=user).exists()
 
 
 modal_critical = CriticalModal()

--- a/src/firefighter/slack/views/modals/critical.py
+++ b/src/firefighter/slack/views/modals/critical.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+from slack_sdk.models.blocks.blocks import SectionBlock
+from slack_sdk.models.views import View
+
+from firefighter.incidents.forms.create_incident import CreateIncidentForm
+from firefighter.slack.slack_app import SlackApp
+from firefighter.slack.views.modals.base_modal.base import ModalForm
+
+if TYPE_CHECKING:
+    from slack_bolt.context.ack.ack import Ack
+
+    from firefighter.incidents.models.incident import Priority, Severity
+    from firefighter.incidents.models.user import User
+    from firefighter.slack.views.modals.base_modal.form_utils import (
+        SlackFormAttributesDict,
+    )
+
+app = SlackApp()
+logger = logging.getLogger(__name__)
+
+
+def priority_label(obj: Severity | Priority) -> str:
+    return f"{obj.emoji}  {obj.name} - {obj.description}"
+
+
+class CriticalFormSlack(CreateIncidentForm):
+    slack_fields: SlackFormAttributesDict = {
+        "title": {
+            "input": {
+                "multiline": False,
+                "placeholder": "Short, punchy description of what's happening.",
+            },
+            "block": {"hint": None},
+        },
+        "description": {
+            "input": {
+                "multiline": True,
+                "placeholder": "Help people responding to the incident. This will be posted to #tech-incidents and on our internal status page.\nThis description can be edited later.",
+            },
+            "block": {"hint": None},
+        },
+        "component": {
+            "input": {
+                "placeholder": "Select affected component",
+            }
+        },
+        "priority": {
+            "input": {
+                "placeholder": "Select a priority",
+            },
+            "widget": {
+                "post_block": (
+                    SectionBlock(
+                        text=f"_<{settings.SLACK_SEVERITY_HELP_GUIDE_URL}|How to choose the priority?>_"
+                    )
+                    if settings.SLACK_SEVERITY_HELP_GUIDE_URL
+                    else None
+                ),
+                "label_from_instance": priority_label,
+            },
+        },
+    }
+
+
+class CriticalModal(ModalForm[CriticalFormSlack]):
+    open_action: str = "open_modal_incident_critical"
+    open_shortcut = "modal_critical"
+    callback_id: str = "incident_critical"
+
+    form_class = CriticalFormSlack
+
+    def build_modal_fn(self, **kwargs: Any) -> View:
+        form_instance = self.get_form_class()()
+        blocks = form_instance.slack_blocks()
+
+        return View(
+            type="modal",
+            title="Open a critical incident"[:24],
+            submit="Create the incident"[:24],
+            callback_id=self.callback_id,
+            blocks=blocks,
+            clear_on_close=False,
+            close=None,
+        )
+
+    def handle_modal_fn(  # type: ignore
+        self, ack: Ack, body: dict[str, Any], user: User
+    ) -> None :
+        slack_form = self.handle_form_errors(
+            ack, body, forms_kwargs={},
+        )
+
+        if slack_form is None:
+            return
+
+        form = slack_form.form
+
+        try:
+            if hasattr(form, "trigger_incident_workflow") and callable(
+                form.trigger_incident_workflow
+            ):
+                form.trigger_incident_workflow(
+                    creator=user,
+                    impacts_data=None,
+                )
+        except:  # noqa: E722
+            logger.exception("Error triggering incident workflow")
+            # XXX warn the user via DM!
+
+        if len(form.cleaned_data) == 0:
+            logger.warning("Form is empty, no data captured.")
+            return
+
+
+modal_critical = CriticalModal()


### PR DESCRIPTION
# Add Critical Incident Modal for Emergency Responses

## Description
This pull request introduces a new feature that allows users to quickly create critical incidents using the /incident critical command. This streamlined process requires users to fill in only the title, description, component, priority and environment, significantly reducing the time needed to report emergencies.

## Changes Made
- [X] Implemented the /incident critical command for creating critical incidents.
- [X] Created a modal form that requires only essential fields: title, description, component, and priority.
- [ ] Restricted the feature to "advanced users" (users in an incident response group/on-call).

## Motivation and Context
This change is important as it addresses the need for a more efficient way to report critical incidents during emergency situations. By simplifying the reporting process, we ensure that users can quickly communicate essential information, facilitating faster responses.

## How to Test
1. Ensure you are a member of the incident response group/on-call team.
2. In Slack, use the command /incident critical.
3. Fill in the title, description, component, and priority fields.
4. Submit the form and verify that the incident is created successfully in the system.
5. Check logs for any errors and ensure the incident appears in the incident management system.

## Checklist
- [X] I have tested my changes
- [X] My code follows the style guidelines of this project
