### PR TITLE
feat(incidents): make Feature Team required for P4/P5 incidents

### DIFF
--- a/src/firefighter/incidents/forms/unified_incident.py
+++ b/src/firefighter/incidents/forms/unified_incident.py
@@ -125,7 +125,7 @@ class UnifiedIncidentForm(CreateIncidentFormBase):
     suggested_team_routing: forms.ModelChoiceField[Any] = forms.ModelChoiceField(
         queryset=None,  # Will be set in __init__
         label="Feature Team or Train",
-        required=True,
+        required=False,  # Enforced as required for P4-P5 via clean() and Slack field visibility
     )
 
     # === Conditional: Customer impact ===

--- a/src/firefighter/incidents/forms/unified_incident.py
+++ b/src/firefighter/incidents/forms/unified_incident.py
@@ -125,7 +125,7 @@ class UnifiedIncidentForm(CreateIncidentFormBase):
     suggested_team_routing: forms.ModelChoiceField[Any] = forms.ModelChoiceField(
         queryset=None,  # Will be set in __init__
         label="Feature Team or Train",
-        required=False,  # Conditionally required based on response_type
+        required=True,
     )
 
     # === Conditional: Customer impact ===

--- a/src/firefighter/slack/views/modals/opening/details/unified.py
+++ b/src/firefighter/slack/views/modals/opening/details/unified.py
@@ -147,6 +147,10 @@ class UnifiedIncidentFormSlack(UnifiedIncidentForm):
         for field_name in fields_to_remove:
             del self.fields[field_name]
 
+        # Feature Team is required for P4-P5 incidents
+        if "suggested_team_routing" in self.fields:
+            self.fields["suggested_team_routing"].required = True
+
 
 class OpeningUnifiedModal(SetIncidentDetails[UnifiedIncidentFormSlack]):
     """Unified modal for all incident types (P1-P5)."""


### PR DESCRIPTION
## Summary

- Make `suggested_team_routing` field required (`required=True`) for P4/P5 incident creation
- Ensures incidents are always routed to the correct Jira project instead of falling back to the default INCIDENT project
- The Slack modal "(optional)" label is automatically removed since it's driven by `field.required`

## Context

P4/P5 incidents created without a Feature Team were silently routed to the default INCIDENT Jira project. The field was displayed in the Slack modal but marked as optional, allowing users to skip it.

## Scope

- **P4/P5 (normal)**: Field is now mandatory — form validation rejects submission without it
- **P1-P3 (critical)**: No change — the field is removed from the form entirely via `_configure_field_visibility`
- **API (serializer)**: Already `required=True` — no change needed

## Test plan

- [ ] Open Slack modal for P4/P5 → verify "(optional)" is no longer shown on Feature Team field
- [ ] Submit P4/P5 without Feature Team → verify Slack shows validation error
- [ ] Submit P4/P5 with Feature Team → verify ticket is routed to correct Jira project
- [ ] Submit P1-P3 → verify Feature Team field is not shown and creation works normally
- [ ] Run existing test suite: `pytest tests/test_incidents/test_forms/`