### PR TITLE
test(raid): use resolvable domains in landbot test fixture

### DIFF
--- a/tests/test_api/test_api_landbot.py
+++ b/tests/test_api/test_api_landbot.py
@@ -23,7 +23,7 @@ base_valid_data = {
     "issue_type": "Incident",
     "business_impact": "High",
     "priority": 1,
-    "attachments": "['https://test-attachment.com/test1','https://test-attachment2.com/test2',]",
+    "attachments": "['https://example.com/test1','https://example.org/test2',]",
 }
 
 


### PR DESCRIPTION
The SSRF guard added in 0.0.54 resolves attachment URLs via socket.getaddrinfo to reject private/link-local hosts. The existing landbot serializer test fixture used the fake domains test-attachment.com / test-attachment2.com which do not resolve on GitHub Actions runners, so serializer validation now raises ValidationError('host could not be resolved') and tests fail non-deterministically depending on DNS cache state.

Switch to IANA-reserved example.com / example.org — always resolvable, stable, and documented for this purpose.