### PR TITLE
fix(slack): preserve priority/category when closure reason modal is pushed

### DIFF
--- a/src/firefighter/slack/slack_incident_context.py
+++ b/src/firefighter/slack/slack_incident_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
@@ -104,14 +105,48 @@ def get_incident_from_view_submission_metadata(
     if view_type not in {"view_submission", "block_actions"}:
         return False
 
+    incident_id = _extract_incident_id_from_private_metadata(private_metadata)
+    if incident_id is None:
+        return None
+    return Incident.objects.get(id=incident_id)
+
+
+def _extract_incident_id_from_private_metadata(
+    private_metadata: str,
+) -> int | None:
+    """Extract an incident ID from a Slack view's private_metadata.
+
+    Supports two formats:
+    - Legacy: the raw incident ID as a string (e.g. "123").
+    - Extended: a JSON object with an "incident_id" key (e.g. {"incident_id": 123, ...}),
+      used when callers need to carry additional state alongside the incident ID.
+    """
     try:
-        incident_id = int(private_metadata)
+        return int(private_metadata)
     except ValueError:
+        pass
+
+    try:
+        parsed = json.loads(private_metadata)
+    except (json.JSONDecodeError, TypeError):
         logger.warning(
             f"Response.view.private_metadata ('{private_metadata}') was not a valid incident ID!"
         )
         return None
-    return Incident.objects.get(id=incident_id)
+
+    if not isinstance(parsed, dict) or "incident_id" not in parsed:
+        logger.warning(
+            f"Response.view.private_metadata ('{private_metadata}') has no incident_id!"
+        )
+        return None
+
+    try:
+        return int(parsed["incident_id"])
+    except (ValueError, TypeError):
+        logger.warning(
+            f"Response.view.private_metadata.incident_id ('{parsed['incident_id']}') was not a valid incident ID!"
+        )
+        return None
 
 
 @incident_resolve_strategy

--- a/src/firefighter/slack/views/modals/closure_reason.py
+++ b/src/firefighter/slack/views/modals/closure_reason.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -42,9 +43,19 @@ class ClosureReasonModal(IncidentSelectableModalMixin, SlackModal):
     callback_id: str = "incident_closure_reason"
 
     def build_modal_fn(
-        self, body: dict[str, Any], incident: Incident, **kwargs: Any  # noqa: ARG002
+        self,
+        body: dict[str, Any],  # noqa: ARG002
+        incident: Incident,
+        carry_over: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> View:
-        """Build the closure reason modal."""
+        """Build the closure reason modal.
+
+        `carry_over` lets upstream callers (Update Status modal) pass form
+        changes that should be applied along with the closure (e.g. a priority
+        change submitted in the same step). Values are serialized into
+        `private_metadata` so they survive the round-trip to Slack.
+        """
         # Build closure reason options (exclude RESOLVED)
         closure_options = [
             Option(
@@ -107,7 +118,7 @@ class ClosureReasonModal(IncidentSelectableModalMixin, SlackModal):
             title=f"Close #{incident.id}"[:24],
             submit="Close Incident",
             callback_id=self.callback_id,
-            private_metadata=str(incident.id),
+            private_metadata=_build_private_metadata(incident.id, carry_over),
             blocks=blocks,
         )
 
@@ -127,6 +138,7 @@ class ClosureReasonModal(IncidentSelectableModalMixin, SlackModal):
             or ""
         )
         message = state_values["closure_message"]["input_closure_message"]["value"]
+        carry_over = _extract_carry_over(body)
 
         # For early closure (OPEN/INVESTIGATING), we bypass normal workflow checks
         # For normal closure (MITIGATED/POST_MORTEM), we must validate key events
@@ -184,6 +196,7 @@ class ClosureReasonModal(IncidentSelectableModalMixin, SlackModal):
                 status=IncidentStatus.CLOSED,
                 message=message,
                 event_type="closure_reason",
+                **carry_over,
             )
 
         except Exception:
@@ -232,6 +245,50 @@ class ClosureReasonModal(IncidentSelectableModalMixin, SlackModal):
 
     def get_select_title(self) -> str:
         return "Select an incident to close with a specific reason"
+
+
+# Carry-over kwargs the closure reason modal will re-apply when closing the
+# incident. Whitelisted to keep deserialization tight and avoid passing unknown
+# kwargs to ``create_incident_update``.
+_ALLOWED_CARRY_OVER_KEYS: frozenset[str] = frozenset(
+    {"priority_id", "incident_category_id"}
+)
+
+
+def _build_private_metadata(
+    incident_id: int, carry_over: dict[str, Any] | None
+) -> str:
+    """Serialize the closure modal's private metadata.
+
+    Without carry-over we keep the legacy plain-int format for backwards
+    compatibility. When carry-over fields are present we switch to a JSON
+    object — the incident resolver supports both shapes.
+    """
+    sanitized = {
+        k: v
+        for k, v in (carry_over or {}).items()
+        if k in _ALLOWED_CARRY_OVER_KEYS and v is not None
+    }
+    if not sanitized:
+        return str(incident_id)
+    return json.dumps({"incident_id": incident_id, "carry_over": sanitized})
+
+
+def _extract_carry_over(body: dict[str, Any]) -> dict[str, Any]:
+    """Read carry-over kwargs back from the submitted view's private_metadata."""
+    raw = body.get("view", {}).get("private_metadata")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    carry_over = parsed.get("carry_over")
+    if not isinstance(carry_over, dict):
+        return {}
+    return {k: v for k, v in carry_over.items() if k in _ALLOWED_CARRY_OVER_KEYS}
 
 
 modal_closure_reason = ClosureReasonModal()

--- a/src/firefighter/slack/views/modals/update_status.py
+++ b/src/firefighter/slack/views/modals/update_status.py
@@ -117,7 +117,9 @@ class UpdateStatusModal(ModalForm[UpdateStatusFormSlack]):
         # Check if user is trying to close and needs a closure reason
         if "status" in form.changed_data:
             target_status = form.cleaned_data["status"]
-            if handle_update_status_close_request(ack, body, incident, target_status):
+            if handle_update_status_close_request(
+                ack, body, incident, target_status, form=form
+            ):
                 return
 
             # Validate that incident can be closed (check key events, post-mortem, etc.)

--- a/src/firefighter/slack/views/modals/utils.py
+++ b/src/firefighter/slack/views/modals/utils.py
@@ -8,9 +8,15 @@ from firefighter.incidents.forms.update_status import UpdateStatusForm
 from firefighter.slack.views.modals.closure_reason import modal_closure_reason
 
 if TYPE_CHECKING:
+    from django.forms import Form
     from slack_sdk.models.views import View
 
     from firefighter.incidents.models.incident import Incident
+
+
+# Fields from the Update Status form that can be carried over to the closure
+# reason modal so changes are not lost when Slack pushes the second modal.
+_CARRY_OVER_FK_FIELDS: tuple[str, ...] = ("priority", "incident_category")
 
 
 def get_close_modal_view(body: dict[str, Any], incident: Incident, **kwargs: Any) -> View | None:
@@ -37,15 +43,46 @@ def handle_close_modal_callback(ack: Any, body: dict[str, Any], incident: Incide
     return None
 
 
-def handle_update_status_close_request(ack: Any, body: dict[str, Any], incident: Incident, target_status: IncidentStatus) -> bool:
+def handle_update_status_close_request(
+    ack: Any,
+    body: dict[str, Any],
+    incident: Incident,
+    target_status: IncidentStatus,
+    form: Form | None = None,
+) -> bool:
     """Handle update status request to close incident, showing reason modal if needed.
+
+    When the closure reason modal is pushed on top of the Update Status modal,
+    the Update Status submission is dropped by Slack. Any fields that were
+    changed alongside the status (priority, incident_category, ...) would be
+    silently lost. To avoid that, we collect those changes from the form and
+    pass them as carry-over data so the closure reason modal can re-apply them
+    on submission.
 
     Returns True if the request was handled (reason modal shown), False otherwise.
     """
     if (target_status == IncidentStatus.CLOSED and
         UpdateStatusForm.requires_closure_reason(incident, target_status)):
-        # Show closure reason modal instead
-        ack(response_action="push", view=modal_closure_reason.build_modal_fn(body, incident))
+        carry_over = _build_carry_over_from_form(form)
+        ack(
+            response_action="push",
+            view=modal_closure_reason.build_modal_fn(
+                body, incident, carry_over=carry_over
+            ),
+        )
         return True
 
     return False
+
+
+def _build_carry_over_from_form(form: Form | None) -> dict[str, Any]:
+    """Collect carry-over fields from the Update Status form's changed data."""
+    if form is None:
+        return {}
+    carry_over: dict[str, Any] = {}
+    changed = set(getattr(form, "changed_data", []) or [])
+    cleaned = getattr(form, "cleaned_data", {}) or {}
+    for field in _CARRY_OVER_FK_FIELDS:
+        if field in changed and cleaned.get(field) is not None:
+            carry_over[f"{field}_id"] = str(cleaned[field].id)
+    return carry_over

--- a/tests/test_slack/views/modals/test_closure_reason_modal.py
+++ b/tests/test_slack/views/modals/test_closure_reason_modal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,9 @@ from slack_sdk.errors import SlackApiError
 from firefighter.incidents.enums import ClosureReason, IncidentStatus
 from firefighter.incidents.factories import IncidentFactory, UserFactory
 from firefighter.incidents.models import Environment, Priority
+from firefighter.slack.slack_incident_context import (
+    _extract_incident_id_from_private_metadata,
+)
 from firefighter.slack.views.modals.closure_reason import ClosureReasonModal
 
 
@@ -235,3 +239,202 @@ class TestClosureReasonModalEarlyClosureBypass:
 
         # Ack should clear modal stack
         ack.assert_called_once_with(response_action="clear")
+
+
+@pytest.mark.django_db
+class TestClosureReasonModalCarryOver:
+    """Closure reason modal must apply fields carried over from Update Status."""
+
+    def test_build_modal_fn_keeps_plain_metadata_without_carry_over(self) -> None:
+        """No carry-over → keep the legacy plain-int private_metadata format."""
+        incident = IncidentFactory.create(_status=IncidentStatus.INVESTIGATING)
+        modal = ClosureReasonModal()
+
+        view = modal.build_modal_fn(body={}, incident=incident)
+
+        assert view.private_metadata == str(incident.id)
+
+    def test_build_modal_fn_encodes_carry_over_into_private_metadata(self) -> None:
+        """Carry-over fields should be serialised into the JSON private_metadata."""
+        incident = IncidentFactory.create(_status=IncidentStatus.INVESTIGATING)
+        modal = ClosureReasonModal()
+
+        carry_over = {
+            "priority_id": "00000000-0000-0000-0000-000000000010",
+            "incident_category_id": "00000000-0000-0000-0000-000000000020",
+        }
+        view = modal.build_modal_fn(body={}, incident=incident, carry_over=carry_over)
+
+        parsed = json.loads(view.private_metadata)
+        assert parsed == {"incident_id": incident.id, "carry_over": carry_over}
+
+        # The incident resolver must still recover the incident from this JSON format
+        assert _extract_incident_id_from_private_metadata(view.private_metadata) == incident.id
+
+    def test_build_modal_fn_drops_unknown_carry_over_keys(self) -> None:
+        """Only whitelisted carry-over keys are serialised."""
+        incident = IncidentFactory.create(_status=IncidentStatus.INVESTIGATING)
+        modal = ClosureReasonModal()
+
+        view = modal.build_modal_fn(
+            body={},
+            incident=incident,
+            carry_over={
+                "priority_id": "00000000-0000-0000-0000-000000000010",
+                "rogue_field": "should-be-dropped",
+            },
+        )
+
+        parsed = json.loads(view.private_metadata)
+        assert parsed["carry_over"] == {
+            "priority_id": "00000000-0000-0000-0000-000000000010",
+        }
+
+    def test_handle_modal_fn_applies_carried_over_priority(self, mocker) -> None:
+        """Submitting the closure modal must re-apply the priority carried over."""
+        priority_initial = Priority.objects.create(
+            name="P1-test-init",
+            value=9001,
+            description="P1 test init",
+            order=9001,
+            needs_postmortem=True,
+        )
+        priority_new = Priority.objects.create(
+            name="P3-test-carry",
+            value=9003,
+            description="P3 carry-over",
+            order=9003,
+            needs_postmortem=False,
+        )
+
+        user = UserFactory.create()
+        incident = IncidentFactory.create(
+            _status=IncidentStatus.INVESTIGATING,
+            created_by=user,
+            priority=priority_initial,
+        )
+
+        # Allow early closure regardless of validation details
+        mocker.patch.object(
+            type(incident),
+            "can_be_closed",
+            new_callable=mocker.PropertyMock,
+            return_value=(True, []),
+        )
+
+        modal = ClosureReasonModal()
+        ack = MagicMock()
+
+        body = {
+            "view": {
+                "state": {
+                    "values": {
+                        "closure_reason": {
+                            "select_closure_reason": {
+                                "selected_option": {"value": ClosureReason.CANCELLED}
+                            }
+                        },
+                        "closure_reference": {
+                            "input_closure_reference": {"value": ""}
+                        },
+                        "closure_message": {
+                            "input_closure_message": {
+                                "value": "Closed with priority change"
+                            }
+                        },
+                    }
+                },
+                "private_metadata": json.dumps({
+                    "incident_id": incident.id,
+                    "carry_over": {"priority_id": str(priority_new.id)},
+                }),
+            },
+            "user": {"id": "U123456"},
+        }
+
+        with patch(
+            "firefighter.slack.views.modals.closure_reason.respond"
+        ) as mock_respond:
+            mock_respond.return_value = None
+
+            result = modal.handle_modal_fn(
+                ack=ack, body=body, incident=incident, user=user
+            )
+
+        assert result is True
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.CLOSED
+        assert incident.priority_id == priority_new.id, (
+            "The priority change submitted in the Update Status modal must be "
+            "applied alongside the closure."
+        )
+
+    def test_handle_modal_fn_ignores_invalid_carry_over_payload(self, mocker) -> None:
+        """A malformed carry_over payload must not block closure."""
+        user = UserFactory.create()
+        incident = IncidentFactory.create(
+            _status=IncidentStatus.INVESTIGATING,
+            created_by=user,
+        )
+
+        mocker.patch.object(
+            type(incident),
+            "can_be_closed",
+            new_callable=mocker.PropertyMock,
+            return_value=(True, []),
+        )
+
+        modal = ClosureReasonModal()
+        ack = MagicMock()
+
+        body = {
+            "view": {
+                "state": {
+                    "values": {
+                        "closure_reason": {
+                            "select_closure_reason": {
+                                "selected_option": {"value": ClosureReason.CANCELLED}
+                            }
+                        },
+                        "closure_reference": {"input_closure_reference": {"value": ""}},
+                        "closure_message": {
+                            "input_closure_message": {"value": "ok"}
+                        },
+                    }
+                },
+                # Intentionally malformed JSON
+                "private_metadata": "{not valid json",
+            },
+            "user": {"id": "U123456"},
+        }
+
+        with patch(
+            "firefighter.slack.views.modals.closure_reason.respond"
+        ) as mock_respond:
+            mock_respond.return_value = None
+
+            result = modal.handle_modal_fn(
+                ack=ack, body=body, incident=incident, user=user
+            )
+
+        assert result is True
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.CLOSED
+
+
+@pytest.mark.django_db
+class TestExtractIncidentIdFromPrivateMetadata:
+    """The incident resolver must accept both legacy and JSON private_metadata."""
+
+    def test_legacy_plain_int(self) -> None:
+        assert _extract_incident_id_from_private_metadata("42") == 42
+
+    def test_json_with_incident_id(self) -> None:
+        payload = json.dumps({"incident_id": 99, "carry_over": {"priority_id": "x"}})
+        assert _extract_incident_id_from_private_metadata(payload) == 99
+
+    def test_invalid_payload_returns_none(self) -> None:
+        assert _extract_incident_id_from_private_metadata("not-json-not-int") is None
+
+    def test_json_without_incident_id_returns_none(self) -> None:
+        assert _extract_incident_id_from_private_metadata(json.dumps({"foo": "bar"})) is None

--- a/tests/test_slack/views/modals/test_update_status.py
+++ b/tests/test_slack/views/modals/test_update_status.py
@@ -353,10 +353,14 @@ class TestUpdateStatusModal:
             ack=ack, body=submission_copy, incident=incident, user=user
         )
 
-        # Verify handle_update_status_close_request was called
-        mock_handle_close.assert_called_once_with(
-            ack, submission_copy, incident, IncidentStatus.CLOSED
-        )
+        # Verify handle_update_status_close_request was called and that the
+        # submitted form was forwarded so its carry-over fields (priority,
+        # incident_category) can be re-applied at closure time.
+        mock_handle_close.assert_called_once()
+        call_args, call_kwargs = mock_handle_close.call_args
+        assert call_args == (ack, submission_copy, incident, IncidentStatus.CLOSED)
+        assert "form" in call_kwargs
+        assert call_kwargs["form"] is not None
 
         # Verify that incident update was NOT triggered (because closure reason modal was shown)
         trigger_incident_workflow.assert_not_called()

--- a/tests/test_slack/views/modals/test_utils.py
+++ b/tests/test_slack/views/modals/test_utils.py
@@ -95,7 +95,71 @@ class TestModalUtils:
 
             assert result is True
             ack.assert_called_once_with(response_action="push", view=mock_build.return_value)
-            mock_build.assert_called_once_with(body, incident)
+            mock_build.assert_called_once_with(body, incident, carry_over={})
+
+    def test_handle_update_status_close_request_passes_carry_over(self):
+        """A priority/category change submitted with status=CLOSED must be carried over."""
+        incident = IncidentFactory.create(_status=IncidentStatus.OPEN)
+        ack = MagicMock()
+        body = {}
+        target_status = IncidentStatus.CLOSED
+
+        # Build a fake form with changed_data + cleaned_data for priority and category
+        priority = MagicMock()
+        priority.id = "00000000-0000-0000-0000-000000000001"
+        category = MagicMock()
+        category.id = "00000000-0000-0000-0000-000000000002"
+        form = MagicMock()
+        form.changed_data = ["status", "priority", "incident_category"]
+        form.cleaned_data = {
+            "status": IncidentStatus.CLOSED,
+            "priority": priority,
+            "incident_category": category,
+        }
+
+        with patch("firefighter.slack.views.modals.utils.UpdateStatusForm.requires_closure_reason", return_value=True), \
+             patch("firefighter.slack.views.modals.utils.modal_closure_reason.build_modal_fn") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            result = handle_update_status_close_request(
+                ack, body, incident, target_status, form=form
+            )
+
+            assert result is True
+            mock_build.assert_called_once_with(
+                body,
+                incident,
+                carry_over={
+                    "priority_id": str(priority.id),
+                    "incident_category_id": str(category.id),
+                },
+            )
+
+    def test_handle_update_status_close_request_carry_over_ignores_untouched(self):
+        """Fields that are not in changed_data must not be carried over."""
+        incident = IncidentFactory.create(_status=IncidentStatus.OPEN)
+        ack = MagicMock()
+        body = {}
+        target_status = IncidentStatus.CLOSED
+
+        priority = MagicMock()
+        priority.id = "00000000-0000-0000-0000-000000000003"
+        form = MagicMock()
+        form.changed_data = ["status"]  # Only status changed
+        form.cleaned_data = {
+            "status": IncidentStatus.CLOSED,
+            "priority": priority,  # Present but not changed
+        }
+
+        with patch("firefighter.slack.views.modals.utils.UpdateStatusForm.requires_closure_reason", return_value=True), \
+             patch("firefighter.slack.views.modals.utils.modal_closure_reason.build_modal_fn") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            handle_update_status_close_request(
+                ack, body, incident, target_status, form=form
+            )
+
+            mock_build.assert_called_once_with(body, incident, carry_over={})
 
     def test_handle_update_status_close_request_no_reason_required(self):
         """Test handle_update_status_close_request when reason is not required."""


### PR DESCRIPTION
## Summary

When closing an incident from `OPEN` / `INVESTIGATING` via the **Update Status** modal, Slack pushes the **Closure Reason** modal on top of it. Any field the user had changed alongside the status (e.g. setting the priority to P3) was silently dropped, because:

- The Update Status submission was short-circuited with `ack(response_action="push", ...)` and `return` before its `update_kwargs` block ran.
- The Closure Reason modal only read its own three inputs (`closure_reason`, `closure_reference`, `closure_message`).
- `private_metadata` carried only the incident ID.

This MR carries the changed fields through the Closure Reason modal's `private_metadata` (now a JSON object containing `incident_id` and a whitelisted `carry_over` dict) and re-applies them at closure time. The incident resolver in `slack_incident_context` accepts **both** the legacy plain-int format and the new JSON shape, so callers without carry-over data (direct `/incident close`, etc.) are unchanged.

### Reported behaviour

> "j'ai fait un update to P3 + message de closure dans le premier form, mais ça m'a emmené sur un second form de fermeture qui a ignoré le passage en P3."

### Fields affected (now propagated)

- `priority`
- `incident_category`

The `message` field already had an equivalent in the Closure Reason modal (`closure_message`), so the user re-typed it. `title` / `description` are not exposed in `UpdateStatusForm`. Carry-over is strictly whitelisted on both encode and decode to keep the surface tight.

### Atomicity

Carry-over lives in `private_metadata` on Slack's side — if the user cancels the Closure Reason modal, no DB write happens. The change is applied alongside the closure in a single `create_incident_update(...)` call.

## Test plan

- [x] `pytest tests/test_slack/views/modals/test_utils.py tests/test_slack/views/modals/test_closure_reason_modal.py tests/test_slack/views/modals/test_update_status.py tests/test_slack/views/modals/test_close.py` — 30 passed, 1 skipped.
- [x] `pdm run lint-ruff --output-format=github --exit-non-zero-on-fix` — clean.
- [x] `pdm run lint-mypy` — Success: no issues found in 368 source files.
- [x] Pre-commit hooks pass (ruff, mypy, end-of-files, etc).
- [ ] Manual smoke on staging: open an incident in INVESTIGATING, run **Update Status** with status=CLOSED + priority changed → submit → fill Closure Reason → submit → verify priority is updated on the incident in addition to the closure fields.
- [ ] Manual smoke for the legacy path: `/incident close` on a MITIGATED/POST_MORTEM incident → ensure incident resolution still works (proves the legacy plain-int `private_metadata` parser still applies).

## Notes

- New tests cover the whitelist (unknown keys dropped), the round-trip via `private_metadata`, malformed JSON resilience, and the `_extract_incident_id_from_private_metadata` helper for both formats.
- Pre-existing failures in `tests/test_incidents/test_forms/test_unified_incident_form_integration.py` were verified to be unrelated (reproduced on `origin/main`).