### PR TITLE
chore(docker-compose): upgrade local postgres to 18-alpine

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,14 +5,14 @@
 services:
   db:
     container_name: ff-db
-    image: postgres:13-alpine
+    image: postgres:18-alpine
     env_file:
       - ".env"
     restart: unless-stopped
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
-      - firefighter-pg-13:/var/lib/postgresql/data
+      - firefighter-pg-18:/var/lib/postgresql
     security_opt:
       - no-new-privileges:true
 
@@ -43,5 +43,5 @@ services:
       ADMINER_DESIGN: nette
 
 volumes:
-  firefighter-pg-13:
+  firefighter-pg-18:
   firefighter-redis:


### PR DESCRIPTION
## Summary

- Bump the local-dev Postgres image from `postgres:13-alpine` to `postgres:18-alpine`.
- Rename the named volume `firefighter-pg-13` → `firefighter-pg-18` to force a fresh `initdb` rather than silently reusing a PG 13 cluster.
- Move the volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql` because PG 18+ stores the cluster under a version-prefixed subdirectory (`/var/lib/postgresql/18/data`) and refuses to start otherwise.

## Why

PG 13 reached end of life upstream. Aligning the local dev stack on the same major used in the support DB snapshot/restore workflow avoids dump/restore mismatches.

## Test plan

- [x] `docker compose down && docker volume rm firefighter-oss_firefighter-pg-13 && docker compose up -d db` brings up a healthy PG 18 instance.
- [x] `docker exec ff-db pg_isready -U firefighter` returns `accepting connections`.
- [ ] CI green.