### PR TITLE
fix(raid): skip Jira ticket watchers whose email is excluded by config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,10 @@ RAID_JIRA_PROJECT_KEY="T2"
 RAID_TOOLBOX_URL=https://toolbox.mycompany.com/login
 RAID_JIRA_INCIDENT_CATEGORY_FIELD="customfield_12369"
 
+# Comma-separated emails to skip when notifying Jira ticket watchers (service or bot accounts with no usable Slack mapping).
+# Default: empty (no exclusions).
+# RAID_WATCHER_EMAIL_EXCLUSIONS=service-account@example.com,bot@example.com
+
 ## JIRA Post-mortem settings (optional, needs JIRA settings)
 ENABLE_JIRA_POSTMORTEM=False
 # Required settings for the integration

--- a/src/firefighter/firefighter/settings/components/raid.py
+++ b/src/firefighter/firefighter/settings/components/raid.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decouple import Csv
+
 from firefighter.firefighter.settings.components.common import INSTALLED_APPS
 from firefighter.firefighter.settings.settings_utils import config
 
@@ -23,3 +25,14 @@ if ENABLE_RAID:
 
     RAID_JIRA_INCIDENT_CATEGORY_FIELD: str = config("RAID_JIRA_INCIDENT_CATEGORY_FIELD", default="")
     "Jira custom field ID for incident category (e.g. 'customfield_12345')"
+
+    RAID_WATCHER_EMAIL_EXCLUSIONS: list[str] = [
+        email.strip().lower()
+        for email in config(
+            "RAID_WATCHER_EMAIL_EXCLUSIONS",
+            default="",
+            cast=Csv(),
+        )
+        if email.strip()
+    ]
+    "Comma-separated emails to skip when notifying Jira ticket watchers. Use it for service or bot accounts that have no usable Slack mapping (e.g. shared automation users)."

--- a/src/firefighter/raid/forms.py
+++ b/src/firefighter/raid/forms.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 RAID_DEFAULT_JIRA_QRAFT_USER_ID: str = settings.RAID_DEFAULT_JIRA_QRAFT_USER_ID
+RAID_WATCHER_EMAIL_EXCLUSIONS: frozenset[str] = frozenset(
+    getattr(settings, "RAID_WATCHER_EMAIL_EXCLUSIONS", []) or []
+)
 
 
 class PlatformChoices(models.TextChoices):
@@ -217,6 +220,15 @@ def send_message_to_watchers(
             if watcher.get("accountType") == "app":
                 logger.info(
                     f"Skipping sending message to jira_user_id={watcher_account_id}: is an app"
+                )
+                continue
+
+            watcher_email = (watcher.get("emailAddress") or "").strip().lower()
+            if watcher_email and watcher_email in RAID_WATCHER_EMAIL_EXCLUSIONS:
+                logger.info(
+                    "Skipping sending message to jira_user_id=%s (email=%s): excluded by RAID_WATCHER_EMAIL_EXCLUSIONS",
+                    watcher_account_id,
+                    watcher_email,
                 )
                 continue
             if not JiraUser.objects.filter(id=watcher_account_id).exists():

--- a/tests/test_raid/test_raid_forms.py
+++ b/tests/test_raid/test_raid_forms.py
@@ -450,6 +450,31 @@ class TestSendMessageToWatchers:
         # Then
         assert result is True
 
+    @patch(
+        "firefighter.raid.forms.RAID_WATCHER_EMAIL_EXCLUSIONS",
+        frozenset({"teamqraft@manomano.com"}),
+    )
+    @patch("firefighter.raid.forms.jira_client")
+    def test_send_message_to_watchers_skips_excluded_email(self, mock_jira_client):
+        """Watchers whose emailAddress matches RAID_WATCHER_EMAIL_EXCLUSIONS are skipped before any DB lookup."""
+        # Given
+        watchers = [
+            {
+                "accountId": "jira-service-account",
+                "accountType": "atlassian",
+                "emailAddress": "TeamQraft@manomano.com",
+            },
+        ]
+        mock_jira_client.get_watchers_from_jira_ticket.return_value = watchers
+        mock_message = Mock()
+
+        # When
+        result = send_message_to_watchers(10001, mock_message)
+
+        # Then
+        assert result is True
+        mock_jira_client.get_jira_user_from_jira_id.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestGetBusinessImpact:

--- a/tests/test_raid/test_raid_forms.py
+++ b/tests/test_raid/test_raid_forms.py
@@ -452,7 +452,7 @@ class TestSendMessageToWatchers:
 
     @patch(
         "firefighter.raid.forms.RAID_WATCHER_EMAIL_EXCLUSIONS",
-        frozenset({"teamqraft@manomano.com"}),
+        frozenset({"service-account@example.com"}),
     )
     @patch("firefighter.raid.forms.jira_client")
     def test_send_message_to_watchers_skips_excluded_email(self, mock_jira_client):
@@ -462,7 +462,7 @@ class TestSendMessageToWatchers:
             {
                 "accountId": "jira-service-account",
                 "accountType": "atlassian",
-                "emailAddress": "TeamQraft@manomano.com",
+                "emailAddress": "Service-Account@example.com",
             },
         ]
         mock_jira_client.get_watchers_from_jira_ticket.return_value = watchers


### PR DESCRIPTION
## Summary

Add a new `RAID_WATCHER_EMAIL_EXCLUSIONS` comma-separated env-driven Django setting that `firefighter.raid.forms.send_message_to_watchers` consults before attempting any DB lookup or Slack notification for a Jira watcher. Watchers whose `emailAddress` (case-insensitive) is in the list are skipped with an `INFO` log entry; the rest of the loop is untouched.

## Why

Shared Jira service / automation accounts (typical examples in our internal usage: `teamqraft@manomano.com`, `admin@manomano.com`) end up watching tickets but have no usable Slack mapping. Each ticket update walks them through `get_jira_user_from_jira_id` → linked `SlackUser` → DM, generating repeated 'no linked Slack user' log lines (and unnecessary DB / API round-trips). Letting operators declare these emails once in env avoids the noise without committing a Manomano-specific hard-coded list to the OSS code path.

## Details

- New setting in `firefighter/firefighter/settings/components/raid.py`. Uses `decouple.Csv`, lowercases / trims entries, default empty list so existing deployments keep the current behaviour until they opt in.
- New short-circuit in `firefighter/raid/forms.py:send_message_to_watchers` between the existing `accountType == 'app'` check and the `JiraUser.objects.filter(...)` check.
- Comparison is case-insensitive on `emailAddress` (Jira returns mixed-case values for some users).

## Test plan

- [x] New unit test `test_send_message_to_watchers_skips_excluded_email` in `tests/test_raid/test_raid_forms.py` asserts the short-circuit fires and `get_jira_user_from_jira_id` is never called.
- [x] Whole `TestSendMessageToWatchers` class passes locally (7/7).
- [x] `pdm run lint-ruff` clean on the three changed files.
- [x] `pdm run lint-mypy` clean (pre-commit hook ran on commit, passed).

## Rollout

Set the env var on the impact deployment after this lands:
```
RAID_WATCHER_EMAIL_EXCLUSIONS=teamqraft@manomano.com,admin@manomano.com
```