### PR TITLE
fix(slack): keep create-incident flow alive when ancillary Slack calls fail

### DIFF
--- a/src/firefighter/slack/signals/create_incident_conversation.py
+++ b/src/firefighter/slack/signals/create_incident_conversation.py
@@ -34,6 +34,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _safely_send_announcement(
+    conversation: Conversation | IncidentChannel,
+    message: Any,
+    *,
+    context: str,
+    incident_id: Any,
+    **send_kwargs: Any,
+) -> None:
+    """Send an announcement message, swallowing SlackApiError so the calling flow keeps running."""
+    try:
+        conversation.send_message_and_save(message, **send_kwargs)
+    except SlackApiError:
+        logger.warning(
+            "Could not post %s in conversation (channel_id=%s) for incident %s",
+            context,
+            getattr(conversation, "channel_id", "?"),
+            incident_id,
+            exc_info=True,
+        )
+
+
 @receiver(signal=create_incident_conversation)
 def create_incident_slack_conversation(
     incident: Incident,
@@ -95,8 +116,12 @@ def create_incident_slack_conversation(
         logger.warning("Could not find user Slack ID for opener_user!")
 
     # Send message in the created channel
-    channel.send_message_and_save(
-        SlackMessageIncidentDeclaredAnnouncement(incident), pin=True
+    _safely_send_announcement(
+        channel,
+        SlackMessageIncidentDeclaredAnnouncement(incident),
+        context="incident declared announcement",
+        incident_id=incident.id,
+        pin=True,
     )
 
     # Post in general channel #tech-incidents if needed
@@ -107,7 +132,12 @@ def create_incident_slack_conversation(
             tag="tech_incidents"
         )
         if tech_incidents_conversation:
-            tech_incidents_conversation.send_message_and_save(announcement_general)
+            _safely_send_announcement(
+                tech_incidents_conversation,
+                announcement_general,
+                context="tech_incidents announcement",
+                incident_id=incident.id,
+            )
         else:
             logger.warning(
                 "Could not find tech_incidents conversation! Is there a channel with tag tech_incidents?"
@@ -126,7 +156,12 @@ def create_incident_slack_conversation(
 
         it_deploy_conversation = Conversation.objects.get_or_none(tag="it_deploy")
         if it_deploy_conversation:
-            it_deploy_conversation.send_message_and_save(announcement_it_deploy)
+            _safely_send_announcement(
+                it_deploy_conversation,
+                announcement_it_deploy,
+                context="it_deploy announcement",
+                incident_id=incident.id,
+            )
         else:
             logger.warning(
                 "Could not find it_deploy conversation! Is there a channel with tag it_deploy?"

--- a/tests/test_slack/test_create_incident_conversation_resilience.py
+++ b/tests/test_slack/test_create_incident_conversation_resilience.py
@@ -1,0 +1,171 @@
+"""Tests for the resilience of the create_incident_conversation signal handler.
+
+When ancillary Slack calls fail (e.g. announcement in #tech-incidents or
+#it-deploy points at a channel ID that does not exist in the current
+workspace), the handler must log the error and keep going so that the
+response team invite and downstream signals still run.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.slack.factories import IncidentChannelFactory, SlackUserFactory
+from firefighter.slack.signals.create_incident_conversation import (
+    create_incident_slack_conversation,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def _build_incident_with_channel() -> tuple[object, object]:
+    user = UserFactory.build()
+    user.save()
+    SlackUserFactory.create(user=user)
+    incident = IncidentFactory.build(created_by=user)
+    incident.save()
+    incident_channel = IncidentChannelFactory.build(incident=incident)
+    incident_channel.save()
+    incident.refresh_from_db()
+    return incident, incident_channel
+
+
+def _patch_handler_dependencies(
+    mocker: MockerFixture,
+    *,
+    tech_conv: object | None,
+    it_deploy_conv: object | None,
+    publish_general: bool = True,
+    publish_it_deploy: bool = True,
+) -> MagicMock:
+    """Replace every external call the handler makes with a controlled mock.
+
+    Returns the MagicMock that stands in for the freshly created incident channel.
+    """
+    new_channel = MagicMock()
+    new_channel.channel_id = "C-NEW-INCIDENT"
+    new_channel.conversations_join.return_value = None
+    new_channel.set_incident_channel_topic.return_value = None
+    new_channel.invite_users.return_value = None
+    new_channel.send_message_and_save.return_value = None
+
+    mocker.patch(
+        "firefighter.slack.signals.create_incident_conversation.IncidentChannel.objects.create_incident_channel",
+        return_value=new_channel,
+    )
+    mocker.patch(
+        "firefighter.slack.signals.create_incident_conversation.should_publish_in_general_channel",
+        return_value=publish_general,
+    )
+    mocker.patch(
+        "firefighter.slack.signals.create_incident_conversation.should_publish_in_it_deploy_channel",
+        return_value=publish_it_deploy,
+    )
+
+    def _lookup(tag: str) -> object | None:
+        return {"tech_incidents": tech_conv, "it_deploy": it_deploy_conv}.get(tag)
+
+    mocker.patch(
+        "firefighter.slack.signals.create_incident_conversation.Conversation.objects.get_or_none",
+        side_effect=_lookup,
+    )
+    return new_channel
+
+
+@pytest.mark.django_db
+class TestCreateIncidentSlackConversationResilience:
+    """Verify ancillary Slack failures do not abort the handler."""
+
+    @staticmethod
+    def test_tech_incidents_send_failure_does_not_abort_flow(
+        mocker: MockerFixture,
+    ) -> None:
+        incident, _ = _build_incident_with_channel()
+        mocker.patch.object(incident, "build_invite_list", return_value=[])
+        mocker.patch.object(incident.conversation, "invite_users")
+
+        tech_conv = MagicMock()
+        tech_conv.channel_id = "C-TECH"
+        tech_conv.send_message_and_save.side_effect = SlackApiError(
+            "channel_not_found", response={}
+        )
+        it_deploy_conv = MagicMock()
+        it_deploy_conv.channel_id = "C-DEPLOY"
+        it_deploy_conv.send_message_and_save.return_value = None
+
+        _patch_handler_dependencies(
+            mocker, tech_conv=tech_conv, it_deploy_conv=it_deploy_conv
+        )
+
+        create_incident_slack_conversation(incident=incident)
+
+        tech_conv.send_message_and_save.assert_called_once()
+        it_deploy_conv.send_message_and_save.assert_called_once()
+        incident.conversation.invite_users.assert_called_once()
+
+    @staticmethod
+    def test_it_deploy_send_failure_does_not_abort_flow(mocker: MockerFixture) -> None:
+        incident, _ = _build_incident_with_channel()
+        mocker.patch.object(incident, "build_invite_list", return_value=[])
+        mocker.patch.object(incident.conversation, "invite_users")
+
+        tech_conv = MagicMock()
+        tech_conv.channel_id = "C-TECH"
+        tech_conv.send_message_and_save.return_value = None
+        it_deploy_conv = MagicMock()
+        it_deploy_conv.channel_id = "C-DEPLOY"
+        it_deploy_conv.send_message_and_save.side_effect = SlackApiError(
+            "channel_not_found", response={}
+        )
+
+        signal_seen: list[object] = []
+        from firefighter.slack.signals import incident_channel_done
+
+        def _capture(**kwargs: object) -> None:
+            signal_seen.append(kwargs)
+
+        incident_channel_done.connect(_capture, weak=False)
+        try:
+            _patch_handler_dependencies(
+                mocker, tech_conv=tech_conv, it_deploy_conv=it_deploy_conv
+            )
+            create_incident_slack_conversation(incident=incident)
+        finally:
+            incident_channel_done.disconnect(_capture)
+
+        it_deploy_conv.send_message_and_save.assert_called_once()
+        assert signal_seen, "incident_channel_done must still be fired after it_deploy failure"
+
+    @staticmethod
+    def test_announcement_send_failure_does_not_abort_flow(
+        mocker: MockerFixture,
+    ) -> None:
+        incident, _ = _build_incident_with_channel()
+        mocker.patch.object(incident, "build_invite_list", return_value=[])
+        mocker.patch.object(incident.conversation, "invite_users")
+
+        tech_conv = MagicMock()
+        tech_conv.channel_id = "C-TECH"
+        tech_conv.send_message_and_save.return_value = None
+        it_deploy_conv = MagicMock()
+        it_deploy_conv.channel_id = "C-DEPLOY"
+        it_deploy_conv.send_message_and_save.return_value = None
+
+        new_channel = _patch_handler_dependencies(
+            mocker, tech_conv=tech_conv, it_deploy_conv=it_deploy_conv
+        )
+        new_channel.send_message_and_save.side_effect = SlackApiError(
+            "rate_limited", response={}
+        )
+
+        create_incident_slack_conversation(incident=incident)
+
+        new_channel.send_message_and_save.assert_called_once()
+        tech_conv.send_message_and_save.assert_called_once()
+        it_deploy_conv.send_message_and_save.assert_called_once()


### PR DESCRIPTION
## Summary

The `create_incident_slack_conversation` signal handler now treats announcement `send_message_and_save` failures as recoverable: each one is wrapped in a try/except that logs at `WARNING` and lets the rest of the flow continue. Implemented as a small `_safely_send_announcement` helper so the three sites (incident-channel welcome, `#tech-incidents`, `#it-deploy`) share the same code path.

## Why

Before this change, any `SlackApiError` from one of these announcement calls bubbled up to `_create_slack_channel` and aborted everything that came afterwards in the same flow:

- response team invite (`incident.conversation.invite_users`)
- `#it-deploy` announcement
- `incident_channel_done` signal (and the downstream side-effects it triggers)

The most common trigger is a `Conversation` row with a stale / wrong-workspace `channel_id` for the `tech_incidents` or `it_deploy` tag: Slack answers `channel_not_found`, the exception escapes, and the rest of the incident-setup flow is silently skipped. We hit this live in a local-dev run (DB restored from support, bot connected to `manomano-test`) but the same shape is plausible on any env after a channel rename / deletion / re-tag.

The invite step that already had a try/except (`channel.invite_users([incident.created_by])` lines 87-93) and the existing skip-list inside the Jira watcher loop already follow this same defensive pattern — this PR brings the rest of the handler in line with them.

## Details

- Added `_safely_send_announcement(conversation, message, *, context, incident_id, **send_kwargs)`. Catches `SlackApiError`, logs at WARNING with `channel_id` and `incident_id` plus `exc_info=True`.
- Routed the three sites through the helper:
  1. Initial welcome message in the freshly created incident channel.
  2. Announcement in `#tech-incidents` (when `should_publish_in_general_channel` is true).
  3. Announcement in `#it-deploy` (when `should_publish_in_it_deploy_channel` is true).
- No behaviour change on the success path; ordering is preserved.

## Tests

New file `tests/test_slack/test_create_incident_conversation_resilience.py` with three focused cases:

- `test_tech_incidents_send_failure_does_not_abort_flow` — tech_incidents raises, it_deploy is still called, response team invite is still called.
- `test_it_deploy_send_failure_does_not_abort_flow` — it_deploy raises, `incident_channel_done` signal is still emitted.
- `test_announcement_send_failure_does_not_abort_flow` — welcome message raises, tech_incidents + it_deploy sends still run.

All three pass locally. Ruff + mypy clean. Pre-existing integration-test failures in `test_unified_incident_form_integration.py` (which make real Slack API calls and rely on workspace state) are unaffected by this change.