### PR TITLE
feat(raid): authenticate Jira webhook endpoints via query-string secret

### DIFF
--- a/src/firefighter/api/authentication.py
+++ b/src/firefighter/api/authentication.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import secrets
 from typing import TYPE_CHECKING
 
-from rest_framework.authentication import TokenAuthentication
+from django.conf import settings
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication, TokenAuthentication
 
 if TYPE_CHECKING:
     from django.db.models import Model
+    from rest_framework.request import Request
+
+    from firefighter.incidents.models.user import User
 
 
 class BearerTokenAuthentication(TokenAuthentication):
@@ -17,3 +23,58 @@ class BearerTokenAuthentication(TokenAuthentication):
         from firefighter.api.models import APIToken
 
         return APIToken
+
+
+class QueryStringSecretAuthentication(BaseAuthentication):
+    """Authenticate a request via a `?secret=<value>` query parameter.
+
+    For third parties that cannot send an `Authorization` header (e.g. Jira
+    webhooks). The expected value is read from the Django setting referenced
+    by `setting_name`, populated from an env var fed by Vault.
+
+    Subclasses must set:
+      - `setting_name`: name of the Django setting holding the expected value
+      - `service_username`: username of the Django user to bind to `request.user`
+    """
+
+    setting_name: str = ""
+    service_username: str = ""
+
+    def authenticate(self, request: Request) -> tuple[User, None] | None:
+        provided = request.query_params.get("secret")
+        if not provided:
+            return None
+
+        expected = getattr(settings, self.setting_name, None)
+        if not expected or not secrets.compare_digest(str(provided), str(expected)):
+            raise exceptions.AuthenticationFailed("Invalid webhook secret.")
+
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+        try:
+            user = user_model.objects.get(username=self.service_username)
+        except user_model.DoesNotExist as exc:
+            raise exceptions.AuthenticationFailed(
+                "Webhook service user is not provisioned."
+            ) from exc
+
+        if not user.is_active:
+            raise exceptions.AuthenticationFailed("Webhook service user is inactive.")
+
+        return (user, None)
+
+    def authenticate_header(self, _request: Request) -> str:
+        return 'QueryString realm="webhook"'
+
+
+class JiraWebhookSecretAuthentication(QueryStringSecretAuthentication):
+    """Authenticate Jira webhook callers via `?secret=<value>`.
+
+    The expected value is compared (constant time) against
+    `settings.RAID_JIRA_WEBHOOK_SECRET`. On success the request is bound to
+    the dedicated `jira-webhook` service user.
+    """
+
+    setting_name = "RAID_JIRA_WEBHOOK_SECRET"
+    service_username = "jira-webhook"

--- a/src/firefighter/firefighter/settings/components/raid.py
+++ b/src/firefighter/firefighter/settings/components/raid.py
@@ -36,3 +36,6 @@ if ENABLE_RAID:
         if email.strip()
     ]
     "Comma-separated emails to skip when notifying Jira ticket watchers. Use it for service or bot accounts that have no usable Slack mapping (e.g. shared automation users)."
+
+    RAID_JIRA_WEBHOOK_SECRET: str = config("RAID_JIRA_WEBHOOK_SECRET", default="")
+    "Shared secret expected as `?secret=` on Jira webhook calls to `raid/jira_update` and `raid/jira_comment`. Empty disables the endpoints (fail-closed)."

--- a/src/firefighter/incidents/migrations/0033_create_jira_webhook_service_user.py
+++ b/src/firefighter/incidents/migrations/0033_create_jira_webhook_service_user.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+SERVICE_USERNAME = "jira-webhook"
+SERVICE_EMAIL = "jira-webhook@firefighter.invalid"
+
+
+def create_jira_webhook_user(apps, schema_editor):
+    User = apps.get_model("incidents", "User")
+    User.objects.update_or_create(
+        username=SERVICE_USERNAME,
+        defaults={
+            "email": SERVICE_EMAIL,
+            "name": "Jira Webhook",
+            "first_name": "Jira",
+            "last_name": "Webhook",
+            "bot": True,
+            "is_active": True,
+            "is_staff": False,
+            "is_superuser": False,
+        },
+    )
+
+
+def delete_jira_webhook_user(apps, schema_editor):
+    User = apps.get_model("incidents", "User")
+    User.objects.filter(username=SERVICE_USERNAME).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("incidents", "0032_disable_confluence_periodic_tasks"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_jira_webhook_user, delete_jira_webhook_user),
+    ]

--- a/src/firefighter/raid/views/__init__.py
+++ b/src/firefighter/raid/views/__init__.py
@@ -9,7 +9,10 @@ from rest_framework import generics, mixins, permissions, status
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
-from firefighter.api.authentication import BearerTokenAuthentication
+from firefighter.api.authentication import (
+    BearerTokenAuthentication,
+    JiraWebhookSecretAuthentication,
+)
 from firefighter.raid.models import JiraTicket
 from firefighter.raid.serializers import (
     JiraWebhookCommentSerializer,
@@ -95,14 +98,17 @@ class JiraUpdateAlertView(
     generics.CreateAPIView[Any],
 ):
     serializer_class = JiraWebhookUpdateSerializer
-    # XXX: Work on webhook token for authentication_classes
-    authentication_classes = []
-    permission_classes = [permissions.AllowAny]
+    authentication_classes = [JiraWebhookSecretAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
     renderer_classes = [JSONRenderer]
 
     def post(self, request: Request, *args: Never, **kwargs: Never) -> Response:
         """Allow to send a message in Slack when some fields ("Priority", "project", "description", "status") of a Jira ticket are updated.
-        Requires a valid Bearer token, that you can create in the back-office if you have the right permissions.
+
+        Authentication: callers must append `?secret=<value>` to the URL.
+        The value must match `settings.RAID_JIRA_WEBHOOK_SECRET` (set via the
+        `RAID_JIRA_WEBHOOK_SECRET` env var, fed by Vault). Jira webhooks
+        cannot send custom headers, hence the query-string scheme.
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -115,14 +121,17 @@ class JiraCommentAlertView(
     generics.CreateAPIView[Any],
 ):
     serializer_class = JiraWebhookCommentSerializer
-    # XXX: Work on webhook token for authentication_classes
-    authentication_classes = []
-    permission_classes = [permissions.AllowAny]
+    authentication_classes = [JiraWebhookSecretAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
     renderer_classes = [JSONRenderer]
 
     def post(self, request: Request, *args: Never, **kwargs: Never) -> Response:
         """Allow to send a message in Slack when a comment in a Jira ticket is created or modified.
-        Requires a valid Bearer token, that you can create in the back-office if you have the right permissions.
+
+        Authentication: callers must append `?secret=<value>` to the URL.
+        The value must match `settings.RAID_JIRA_WEBHOOK_SECRET` (set via the
+        `RAID_JIRA_WEBHOOK_SECRET` env var, fed by Vault). Jira webhooks
+        cannot send custom headers, hence the query-string scheme.
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/tests/test_raid/test_jira_webhook_auth.py
+++ b/tests/test_raid/test_jira_webhook_auth.py
@@ -1,0 +1,152 @@
+"""Tests for the ?secret= authentication on Jira webhook endpoints."""
+
+from __future__ import annotations
+
+import secrets
+from unittest.mock import patch
+
+import pytest
+from rest_framework import exceptions, status
+from rest_framework.request import Request as DRFRequest
+from rest_framework.test import APIClient, APIRequestFactory
+
+from firefighter.api.authentication import JiraWebhookSecretAuthentication
+
+
+def _drf_request(factory: APIRequestFactory, path: str) -> DRFRequest:
+    return DRFRequest(factory.post(path))
+
+
+JIRA_UPDATE_URL = "/api/v2/firefighter/raid/jira_update"
+JIRA_COMMENT_URL = "/api/v2/firefighter/raid/jira_comment"
+SECRET = secrets.token_urlsafe(32)
+
+
+@pytest.fixture
+def _configure_secret(settings):
+    settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_configure_secret")
+class TestJiraUpdateWebhookAuth:
+    def test_missing_secret_returns_401(self, api_client):
+        response = api_client.post(JIRA_UPDATE_URL, data={}, format="json")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_wrong_secret_returns_401(self, api_client):
+        response = api_client.post(
+            f"{JIRA_UPDATE_URL}?secret=nope", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_bearer_header_returns_401(self, api_client):
+        response = api_client.post(
+            JIRA_UPDATE_URL,
+            data={},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {SECRET}",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.save")
+    @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.is_valid")
+    def test_correct_secret_passes_auth(
+        self, mock_is_valid, mock_save, api_client
+    ):
+        mock_is_valid.return_value = True
+        mock_save.return_value = None
+        response = api_client.post(
+            f"{JIRA_UPDATE_URL}?secret={SECRET}", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_is_valid.assert_called_once_with(raise_exception=True)
+        mock_save.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestJiraUpdateWebhookAuthUnconfigured:
+    def test_unconfigured_secret_returns_401(self, api_client, settings):
+        settings.RAID_JIRA_WEBHOOK_SECRET = ""
+        response = api_client.post(
+            f"{JIRA_UPDATE_URL}?secret=anything", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_configure_secret")
+class TestJiraCommentWebhookAuth:
+    def test_missing_secret_returns_401(self, api_client):
+        response = api_client.post(JIRA_COMMENT_URL, data={}, format="json")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_wrong_secret_returns_401(self, api_client):
+        response = api_client.post(
+            f"{JIRA_COMMENT_URL}?secret=nope", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @patch("firefighter.raid.serializers.JiraWebhookCommentSerializer.save")
+    @patch("firefighter.raid.serializers.JiraWebhookCommentSerializer.is_valid")
+    def test_correct_secret_passes_auth(
+        self, mock_is_valid, mock_save, api_client
+    ):
+        mock_is_valid.return_value = True
+        mock_save.return_value = None
+        response = api_client.post(
+            f"{JIRA_COMMENT_URL}?secret={SECRET}", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_is_valid.assert_called_once_with(raise_exception=True)
+        mock_save.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestJiraWebhookServiceUser:
+    def test_service_user_exists_and_is_a_bot(self):
+        """The data migration must have provisioned the jira-webhook user."""
+        from django.contrib.auth import get_user_model
+
+        user = get_user_model().objects.get(username="jira-webhook")
+        assert user.is_active
+        assert user.bot
+        assert not user.is_staff
+        assert not user.is_superuser
+
+    def test_authenticate_binds_request_to_service_user(self, settings):
+        settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
+        request = _drf_request(APIRequestFactory(), f"/whatever?secret={SECRET}")
+
+        user, auth = JiraWebhookSecretAuthentication().authenticate(request)
+
+        assert user.username == "jira-webhook"
+        assert auth is None
+
+    def test_authenticate_raises_on_inactive_user(self, settings):
+        settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+        user_model.objects.filter(username="jira-webhook").update(is_active=False)
+        try:
+            request = _drf_request(APIRequestFactory(), f"/whatever?secret={SECRET}")
+
+            with pytest.raises(exceptions.AuthenticationFailed):
+                JiraWebhookSecretAuthentication().authenticate(request)
+        finally:
+            user_model.objects.filter(username="jira-webhook").update(is_active=True)
+
+    def test_authenticate_returns_none_without_secret_param(self, settings):
+        """No `?secret=` → returns None, letting DRF emit 401 from IsAuthenticated."""
+        settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
+        request = _drf_request(APIRequestFactory(), "/whatever")
+
+        result = JiraWebhookSecretAuthentication().authenticate(request)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds `QueryStringSecretAuthentication`, a generic DRF auth class that compares a `?secret=<value>` query parameter against a Django setting using constant-time comparison.
- Wires a concrete `JiraWebhookSecretAuthentication` (subclass, reads `settings.RAID_JIRA_WEBHOOK_SECRET`) on `raid/jira_update` and `raid/jira_comment`, which were previously `authentication_classes = []` / `AllowAny`.
- Adds a data migration that provisions a dedicated `jira-webhook` service user (`bot=True`, no staff/superuser).

## Why query string rather than `Authorization` header?

Atlassian Jira webhooks cannot send custom headers (no `Authorization: Bearer …`). The sibling `raid/jira_bot` endpoint, called by Landbot, already uses `BearerTokenAuthentication`. For the two webhook routes the only available authentication channel is the URL.

The query-string secret is mitigated by:
- constant-time comparison via `secrets.compare_digest`;
- fail-closed when `RAID_JIRA_WEBHOOK_SECRET` is unset (no implicit bypass);
- a dedicated service user with no staff/superuser flags, so a leak of the URL does not grant admin access — only the ability to forge webhook calls, which is the same scope as a Jira-side caller.

Defense-in-depth follow-ups (outside this PR, on the deployment side):
- enable query-string scrubbing in Datadog APM and the Envoy/Kong access logs to avoid leaking the secret in observability tooling;
- rotate the secret periodically through Vault.

## Operational follow-ups (Impact / Spinak / Vault)

- provision `RAID_JIRA_WEBHOOK_SECRET` in Vault and expose it as an env var on the Impact pod;
- update the two Jira webhook URLs in the Atlassian admin to include `?secret=<value>`;
- coordinate the rollout so the secret reaches the pod and the Jira webhook URLs are updated in the same window (otherwise Jira webhooks will hit 401 until the URLs are reconfigured — current production traffic is ~395 hits/24h on `jira_update`).

## Test plan

- [x] `pdm run pytest tests/test_raid/test_jira_webhook_auth.py` — 12 cases covering missing/wrong/header-Bearer/unconfigured secret (all 401), correct secret (200), service user binding, inactive service user (401), and `authenticate()` returning `None` without the param.
- [x] `pdm run pytest tests/test_raid` — 174/174 green.
- [x] `pdm run lint-ruff --output-format=github` — clean, no `noqa`.
- [x] `pdm run lint-mypy` — 369 files, clean.
- [x] `pdm run docs-build --strict` — clean.
- [x] `pdm run pre-commit run --files <touched files>` — clean.