### PR TITLE
fix(raid): authenticate Jira webhooks via X-Hub-Signature HMAC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,9 @@ FF_SLACK_SKIP_CHECKS=true
 # Disable SSO redirect for local dev by setting to true but still need a valid URL in OIDC_OP_DISCOVERY_DOCUMENT_URL.
 # When SSO is disabled, go to /admin/ to login
 FF_DEBUG_NO_SSO_REDIRECT=false
+
+# Shared secret used to HMAC-sign Jira webhook bodies on raid/jira_update
+# and raid/jira_comment (verified via the X-Hub-Signature header). The same
+# value must be set in the Atlassian webhook "Secret" field. Empty disables
+# the endpoints (fail-closed). Fed by Vault in non-local environments.
+RAID_JIRA_WEBHOOK_SECRET=""

--- a/src/firefighter/api/authentication.py
+++ b/src/firefighter/api/authentication.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import secrets
+import hashlib
+import hmac
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -25,29 +26,48 @@ class BearerTokenAuthentication(TokenAuthentication):
         return APIToken
 
 
-class QueryStringSecretAuthentication(BaseAuthentication):
-    """Authenticate a request via a `?secret=<value>` query parameter.
+class JiraHmacWebhookAuthentication(BaseAuthentication):
+    """Authenticate Jira webhook callers via the `X-Hub-Signature` header.
 
-    For third parties that cannot send an `Authorization` header (e.g. Jira
-    webhooks). The expected value is read from the Django setting referenced
-    by `setting_name`, populated from an env var fed by Vault.
+    Jira webhooks cannot send custom `Authorization` headers; when a webhook
+    has a Secret configured in the Atlassian admin, Jira signs the raw
+    request body with HMAC and sends the signature in `X-Hub-Signature`,
+    formatted as `method=signature` per the WebSub spec (see
+    https://developer.atlassian.com/cloud/jira/platform/webhooks/).
 
-    Subclasses must set:
-      - `setting_name`: name of the Django setting holding the expected value
-      - `service_username`: username of the Django user to bind to `request.user`
+    The expected secret is read from `settings.RAID_JIRA_WEBHOOK_SECRET`
+    (fed by Vault). Successful calls are bound to the dedicated
+    `jira-webhook` service user provisioned by migration
+    `incidents.0033_create_jira_webhook_service_user`.
     """
 
-    setting_name: str = ""
-    service_username: str = ""
+    setting_name = "RAID_JIRA_WEBHOOK_SECRET"
+    service_username = "jira-webhook"
+    supported_method = "sha256"
 
     def authenticate(self, request: Request) -> tuple[User, None] | None:
-        provided = request.query_params.get("secret")
-        if not provided:
+        header = request.META.get("HTTP_X_HUB_SIGNATURE")
+        if not header:
             return None
 
-        expected = getattr(settings, self.setting_name, None)
-        if not expected or not secrets.compare_digest(str(provided), str(expected)):
-            raise exceptions.AuthenticationFailed("Invalid webhook secret.")
+        expected_secret = getattr(settings, self.setting_name, None)
+        if not expected_secret:
+            raise exceptions.AuthenticationFailed("Webhook secret not configured.")
+
+        method, _, received_sig = header.partition("=")
+        if not received_sig:
+            raise exceptions.AuthenticationFailed("Malformed X-Hub-Signature header.")
+        if method.lower() != self.supported_method:
+            msg = f"Unsupported X-Hub-Signature method: {method!r}"
+            raise exceptions.AuthenticationFailed(msg)
+
+        computed_sig = hmac.new(
+            expected_secret.encode("utf-8"),
+            request.body,
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(computed_sig, received_sig):
+            raise exceptions.AuthenticationFailed("Invalid webhook signature.")
 
         from django.contrib.auth import get_user_model
 
@@ -65,16 +85,4 @@ class QueryStringSecretAuthentication(BaseAuthentication):
         return (user, None)
 
     def authenticate_header(self, _request: Request) -> str:
-        return 'QueryString realm="webhook"'
-
-
-class JiraWebhookSecretAuthentication(QueryStringSecretAuthentication):
-    """Authenticate Jira webhook callers via `?secret=<value>`.
-
-    The expected value is compared (constant time) against
-    `settings.RAID_JIRA_WEBHOOK_SECRET`. On success the request is bound to
-    the dedicated `jira-webhook` service user.
-    """
-
-    setting_name = "RAID_JIRA_WEBHOOK_SECRET"
-    service_username = "jira-webhook"
+        return 'Signature realm="jira-webhook"'

--- a/src/firefighter/incidents/factories.py
+++ b/src/firefighter/incidents/factories.py
@@ -25,7 +25,7 @@ class UserFactory(DjangoModelFactory[User]):
         model = User
 
     name = Faker("name")  # type: ignore[no-untyped-call]
-    email = Faker("email")  # type: ignore[no-untyped-call]
+    email = Sequence(lambda n: f"user_{n}@example.com")  # type: ignore[no-untyped-call]
     username = Sequence(lambda n: f"user_{n}")  # type: ignore[no-untyped-call]
 
 

--- a/src/firefighter/raid/views/__init__.py
+++ b/src/firefighter/raid/views/__init__.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 
 from firefighter.api.authentication import (
     BearerTokenAuthentication,
-    JiraWebhookSecretAuthentication,
+    JiraHmacWebhookAuthentication,
 )
 from firefighter.raid.models import JiraTicket
 from firefighter.raid.serializers import (
@@ -98,17 +98,17 @@ class JiraUpdateAlertView(
     generics.CreateAPIView[Any],
 ):
     serializer_class = JiraWebhookUpdateSerializer
-    authentication_classes = [JiraWebhookSecretAuthentication]
+    authentication_classes = [JiraHmacWebhookAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     renderer_classes = [JSONRenderer]
 
     def post(self, request: Request, *args: Never, **kwargs: Never) -> Response:
         """Allow to send a message in Slack when some fields ("Priority", "project", "description", "status") of a Jira ticket are updated.
 
-        Authentication: callers must append `?secret=<value>` to the URL.
-        The value must match `settings.RAID_JIRA_WEBHOOK_SECRET` (set via the
-        `RAID_JIRA_WEBHOOK_SECRET` env var, fed by Vault). Jira webhooks
-        cannot send custom headers, hence the query-string scheme.
+        Authentication: Jira signs the raw request body with
+        `settings.RAID_JIRA_WEBHOOK_SECRET` and sends the HMAC-SHA256
+        signature in the `X-Hub-Signature: sha256=<hex>` header. Configure
+        the same secret in the Atlassian webhook "Secret" field.
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -121,17 +121,17 @@ class JiraCommentAlertView(
     generics.CreateAPIView[Any],
 ):
     serializer_class = JiraWebhookCommentSerializer
-    authentication_classes = [JiraWebhookSecretAuthentication]
+    authentication_classes = [JiraHmacWebhookAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     renderer_classes = [JSONRenderer]
 
     def post(self, request: Request, *args: Never, **kwargs: Never) -> Response:
         """Allow to send a message in Slack when a comment in a Jira ticket is created or modified.
 
-        Authentication: callers must append `?secret=<value>` to the URL.
-        The value must match `settings.RAID_JIRA_WEBHOOK_SECRET` (set via the
-        `RAID_JIRA_WEBHOOK_SECRET` env var, fed by Vault). Jira webhooks
-        cannot send custom headers, hence the query-string scheme.
+        Authentication: Jira signs the raw request body with
+        `settings.RAID_JIRA_WEBHOOK_SECRET` and sends the HMAC-SHA256
+        signature in the `X-Hub-Signature: sha256=<hex>` header. Configure
+        the same secret in the Atlassian webhook "Secret" field.
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/tests/test_raid/test_jira_webhook_auth.py
+++ b/tests/test_raid/test_jira_webhook_auth.py
@@ -1,7 +1,10 @@
-"""Tests for the ?secret= authentication on Jira webhook endpoints."""
+"""Tests for the X-Hub-Signature HMAC authentication on Jira webhook endpoints."""
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import secrets
 from unittest.mock import patch
 
@@ -10,16 +13,15 @@ from rest_framework import exceptions, status
 from rest_framework.request import Request as DRFRequest
 from rest_framework.test import APIClient, APIRequestFactory
 
-from firefighter.api.authentication import JiraWebhookSecretAuthentication
-
-
-def _drf_request(factory: APIRequestFactory, path: str) -> DRFRequest:
-    return DRFRequest(factory.post(path))
-
+from firefighter.api.authentication import JiraHmacWebhookAuthentication
 
 JIRA_UPDATE_URL = "/api/v2/firefighter/raid/jira_update"
 JIRA_COMMENT_URL = "/api/v2/firefighter/raid/jira_comment"
 SECRET = secrets.token_urlsafe(32)
+
+
+def _sign(secret: str, body: bytes) -> str:
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
 
 
 @pytest.fixture
@@ -35,38 +37,82 @@ def api_client():
 @pytest.mark.django_db
 @pytest.mark.usefixtures("_configure_secret")
 class TestJiraUpdateWebhookAuth:
-    def test_missing_secret_returns_401(self, api_client):
+    def test_missing_header_returns_401(self, api_client):
         response = api_client.post(JIRA_UPDATE_URL, data={}, format="json")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json()["errors"][0]["code"] == "not_authenticated"
 
-    def test_wrong_secret_returns_401(self, api_client):
-        response = api_client.post(
-            f"{JIRA_UPDATE_URL}?secret=nope", data={}, format="json"
-        )
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_bearer_header_returns_401(self, api_client):
+    def test_wrong_signature_returns_401(self, api_client):
         response = api_client.post(
             JIRA_UPDATE_URL,
             data={},
             format="json",
-            HTTP_AUTHORIZATION=f"Bearer {SECRET}",
+            HTTP_X_HUB_SIGNATURE="sha256=" + "0" * 64,
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    def test_malformed_header_returns_401(self, api_client):
+        response = api_client.post(
+            JIRA_UPDATE_URL,
+            data={},
+            format="json",
+            HTTP_X_HUB_SIGNATURE="not-a-valid-format",
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_unsupported_method_returns_401(self, api_client):
+        body = json.dumps({}).encode()
+        response = api_client.post(
+            JIRA_UPDATE_URL,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE="md5=" + "a" * 32,
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_query_string_secret_still_returns_401(self, api_client):
+        """Regression: the old ?secret= scheme is no longer accepted."""
+        response = api_client.post(
+            f"{JIRA_UPDATE_URL}?secret={SECRET}", data={}, format="json"
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.json()["errors"][0]["code"] == "not_authenticated"
+
     @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.save")
     @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.is_valid")
-    def test_correct_secret_passes_auth(
+    def test_valid_signature_passes_auth(
         self, mock_is_valid, mock_save, api_client
     ):
         mock_is_valid.return_value = True
         mock_save.return_value = None
+        body = json.dumps({"webhookEvent": "jira:issue_updated"}).encode()
+        signature = _sign(SECRET, body)
         response = api_client.post(
-            f"{JIRA_UPDATE_URL}?secret={SECRET}", data={}, format="json"
+            JIRA_UPDATE_URL,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE=f"sha256={signature}",
         )
         assert response.status_code == status.HTTP_200_OK
         mock_is_valid.assert_called_once_with(raise_exception=True)
         mock_save.assert_called_once()
+
+    @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.save")
+    @patch("firefighter.raid.serializers.JiraWebhookUpdateSerializer.is_valid")
+    def test_signature_method_is_case_insensitive(
+        self, mock_is_valid, mock_save, api_client
+    ):
+        mock_is_valid.return_value = True
+        mock_save.return_value = None
+        body = json.dumps({}).encode()
+        signature = _sign(SECRET, body)
+        response = api_client.post(
+            JIRA_UPDATE_URL,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE=f"SHA256={signature}",
+        )
+        assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db
@@ -74,7 +120,10 @@ class TestJiraUpdateWebhookAuthUnconfigured:
     def test_unconfigured_secret_returns_401(self, api_client, settings):
         settings.RAID_JIRA_WEBHOOK_SECRET = ""
         response = api_client.post(
-            f"{JIRA_UPDATE_URL}?secret=anything", data={}, format="json"
+            JIRA_UPDATE_URL,
+            data=b"{}",
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE="sha256=" + "f" * 64,
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -82,25 +131,33 @@ class TestJiraUpdateWebhookAuthUnconfigured:
 @pytest.mark.django_db
 @pytest.mark.usefixtures("_configure_secret")
 class TestJiraCommentWebhookAuth:
-    def test_missing_secret_returns_401(self, api_client):
+    def test_missing_header_returns_401(self, api_client):
         response = api_client.post(JIRA_COMMENT_URL, data={}, format="json")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_wrong_secret_returns_401(self, api_client):
+    def test_wrong_signature_returns_401(self, api_client):
         response = api_client.post(
-            f"{JIRA_COMMENT_URL}?secret=nope", data={}, format="json"
+            JIRA_COMMENT_URL,
+            data={},
+            format="json",
+            HTTP_X_HUB_SIGNATURE="sha256=" + "0" * 64,
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     @patch("firefighter.raid.serializers.JiraWebhookCommentSerializer.save")
     @patch("firefighter.raid.serializers.JiraWebhookCommentSerializer.is_valid")
-    def test_correct_secret_passes_auth(
+    def test_valid_signature_passes_auth(
         self, mock_is_valid, mock_save, api_client
     ):
         mock_is_valid.return_value = True
         mock_save.return_value = None
+        body = json.dumps({"webhookEvent": "comment_created"}).encode()
+        signature = _sign(SECRET, body)
         response = api_client.post(
-            f"{JIRA_COMMENT_URL}?secret={SECRET}", data={}, format="json"
+            JIRA_COMMENT_URL,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE=f"sha256={signature}",
         )
         assert response.status_code == status.HTTP_200_OK
         mock_is_valid.assert_called_once_with(raise_exception=True)
@@ -121,9 +178,19 @@ class TestJiraWebhookServiceUser:
 
     def test_authenticate_binds_request_to_service_user(self, settings):
         settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
-        request = _drf_request(APIRequestFactory(), f"/whatever?secret={SECRET}")
+        body = b'{"hello":"world"}'
+        sig = _sign(SECRET, body)
+        factory = APIRequestFactory()
+        request = DRFRequest(
+            factory.post(
+                "/whatever",
+                data=body,
+                content_type="application/json",
+                HTTP_X_HUB_SIGNATURE=f"sha256={sig}",
+            )
+        )
 
-        user, auth = JiraWebhookSecretAuthentication().authenticate(request)
+        user, auth = JiraHmacWebhookAuthentication().authenticate(request)
 
         assert user.username == "jira-webhook"
         assert auth is None
@@ -134,19 +201,29 @@ class TestJiraWebhookServiceUser:
 
         user_model = get_user_model()
         user_model.objects.filter(username="jira-webhook").update(is_active=False)
+        body = b"{}"
+        sig = _sign(SECRET, body)
         try:
-            request = _drf_request(APIRequestFactory(), f"/whatever?secret={SECRET}")
+            factory = APIRequestFactory()
+            request = DRFRequest(
+                factory.post(
+                    "/whatever",
+                    data=body,
+                    content_type="application/json",
+                    HTTP_X_HUB_SIGNATURE=f"sha256={sig}",
+                )
+            )
 
             with pytest.raises(exceptions.AuthenticationFailed):
-                JiraWebhookSecretAuthentication().authenticate(request)
+                JiraHmacWebhookAuthentication().authenticate(request)
         finally:
             user_model.objects.filter(username="jira-webhook").update(is_active=True)
 
-    def test_authenticate_returns_none_without_secret_param(self, settings):
-        """No `?secret=` → returns None, letting DRF emit 401 from IsAuthenticated."""
+    def test_authenticate_returns_none_without_header(self, settings):
         settings.RAID_JIRA_WEBHOOK_SECRET = SECRET
-        request = _drf_request(APIRequestFactory(), "/whatever")
+        factory = APIRequestFactory()
+        request = DRFRequest(factory.post("/whatever"))
 
-        result = JiraWebhookSecretAuthentication().authenticate(request)
+        result = JiraHmacWebhookAuthentication().authenticate(request)
 
         assert result is None


### PR DESCRIPTION
## Summary

Replaces the broken `?secret=` scheme from #299 / 0.0.56 with HMAC-SHA256 signature verification against the `X-Hub-Signature` header — the mechanism Jira actually uses to transmit webhook secrets (WebSub spec).

## Why this PR exists

#299 was rolled back in production on 2026-05-27. The implementation expected callers to append `?secret=<value>` to the URL, but the Atlassian "Secret" field on a webhook does not propagate to the URL — it is used to compute an HMAC-SHA256 of the raw body, sent in `X-Hub-Signature: sha256=<hex>` (https://developer.atlassian.com/cloud/jira/platform/webhooks/, WebSub W3C spec). Our code never read that header, so once 0.0.56 deployed, all webhooks 401'd.

## Changes

- Adds `JiraHmacWebhookAuthentication` (in `firefighter.api.authentication`) that:
  - reads `X-Hub-Signature: <method>=<hex>` and parses it;
  - supports `sha256` (case-insensitive method name); rejects any other algo, malformed value, missing header, or missing setting;
  - computes HMAC-SHA256 over `request.body` with `settings.RAID_JIRA_WEBHOOK_SECRET` and compares with `hmac.compare_digest`;
  - binds successful calls to the `jira-webhook` service user provisioned by migration `incidents.0033`.
- Wires `JiraHmacWebhookAuthentication` on `JiraUpdateAlertView` and `JiraCommentAlertView`. Docstrings updated.
- Removes `QueryStringSecretAuthentication` and `JiraWebhookSecretAuthentication` (no remaining callers).
- Updates `.env.example` to describe the HMAC mechanism.

## How the protocol was validated

Before writing code, the actual `X-Hub-Signature` from a real Jira Cloud webhook was captured via an ngrok tunnel + a tiny local capture server. The recomputed HMAC-SHA256 matched the received signature byte-for-byte using the same secret stored in Vault, confirming:

- header name: `X-Hub-Signature` (case-insensitive in Django via `HTTP_X_HUB_SIGNATURE`)
- format: `sha256=<lowercase hex>`
- bytes signed: the raw request body as received (no normalisation)
- secret encoded as UTF-8 bytes

## Operational notes for the rollout

- The same secret must already be in Vault (`RAID_JIRA_WEBHOOK_SECRET`) and in the Atlassian "Secret" field of each webhook (`Incident Issue Update IMPACT`, `Incidents Issue Comment IMP...`). Both were aligned during the verification step.
- **No change to webhook URLs** on the Atlassian side.
- Defense-in-depth: unlike the rolled-back `?secret=` approach, the secret never appears in the URL/query string, so it does not leak into access logs, traces, or Referer headers.

## Test plan

- [x] 15 unit tests in `tests/test_raid/test_jira_webhook_auth.py`: missing/wrong/malformed/unsupported-method header, valid signature (200), regression on `?secret=` (401), case-insensitive method (200), unconfigured secret (401), service user binding, inactive user (401), `authenticate()` returning `None` without the header.
- [x] Full `tests/test_raid` suite: 178/178.
- [x] Local end-to-end with `runserver` + curl: 10/10 cases, including a real HMAC-signed body returning 200 and the old `?secret=` URL now returning 401.
- [x] `pdm run lint-ruff --output-format=github` — clean, no `noqa`.
- [x] `pdm run lint-mypy` — 369 files, clean.
- [x] `pdm run docs-build --strict` — clean.
- [x] `pdm run pre-commit run --files <touched files>` — clean.