### PR TITLE
fix(raid): match Jira priority sync on field id, not value

### DIFF
--- a/src/firefighter/raid/serializers.py
+++ b/src/firefighter/raid/serializers.py
@@ -355,6 +355,10 @@ class LandbotIssueRequestSerializer(serializers.ModelSerializer[JiraTicket]):
 
 
 class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
+    # Jira custom field holding the FireFighter priority (option values "1".."5").
+    # This is the only priority field Impact reads from / writes to.
+    PRIORITY_FIELD_ID = "customfield_11064"
+
     issue = serializers.DictField()
     changelog = serializers.DictField()
     user = serializers.DictField()
@@ -379,13 +383,8 @@ class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
             # No linked incident: still emit Slack alerts for tracked fields (status/priority).
             for change_item in changes:
                 field = (change_item.get("field") or "").lower()
-                to_val = change_item.get("toString")
-                from_val = change_item.get("fromString")
                 is_status = field == "status"
-                is_priority = (
-                    self._parse_priority_value(to_val) is not None
-                    or self._parse_priority_value(from_val) is not None
-                )
+                is_priority = self._is_priority_change(change_item)
                 if not (is_status or is_priority):
                     continue
                 if not self._alert_slack_update(
@@ -466,12 +465,7 @@ class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
                 raise SlackNotificationError("Could not alert in Slack")
             return self._handle_status_update(validated_data, incident, change_item)
 
-        to_val = change_item.get("toString")
-        from_val = change_item.get("fromString")
-        if (
-            self._parse_priority_value(to_val) is not None
-            or self._parse_priority_value(from_val) is not None
-        ):
+        if self._is_priority_change(change_item):
             if not self._alert_slack_update(
                 validated_data, jira_ticket_key, change_item
             ):
@@ -647,6 +641,23 @@ class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
             cache.delete(cache_key)
             return True
         return False
+
+    @classmethod
+    def _is_priority_change(cls, change_item: dict[str, Any]) -> bool:
+        """Whether a Jira changelog item is a change of the FF priority field.
+
+        Impact owns ``customfield_11064`` exclusively (that is the only field it
+        writes via Impact→Jira sync). The match is made strictly on the field
+        identity, NEVER on the value: a Story Points change (``customfield_10008``)
+        or any other field set to "1".."5" must not be misread as a priority
+        change. See AFP-4216 (Story Points=2 wrongly flipped the incident to P2)
+        and the standard ``priority`` field, which Impact does not manage.
+        """
+        field_id = (change_item.get("fieldId") or "").lower()
+        if field_id:
+            return field_id == cls.PRIORITY_FIELD_ID
+        # Some payloads omit fieldId; fall back to the field name.
+        return (change_item.get("field") or "").lower() == cls.PRIORITY_FIELD_ID
 
     @staticmethod
     def _parse_priority_value(raw: Any) -> int | None:

--- a/tests/test_raid/test_jira_priority_sync.py
+++ b/tests/test_raid/test_jira_priority_sync.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.cache import cache
+
+from firefighter.incidents.models.environment import Environment
+from firefighter.incidents.models.group import Group
+from firefighter.incidents.models.incident import Incident
+from firefighter.incidents.models.incident_category import IncidentCategory
+from firefighter.incidents.models.priority import Priority
+from firefighter.incidents.models.user import User
+from firefighter.raid.serializers import JiraWebhookUpdateSerializer
+
+
+@pytest.fixture(autouse=True)
+def clear_sync_cache() -> None:
+    cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def patch_alert_slack_update_ticket(mocker: pytest.MockFixture) -> MagicMock:
+    return mocker.patch(
+        "firefighter.raid.serializers.alert_slack_update_ticket", return_value=True
+    )
+
+
+def _make_incident() -> Incident:
+    creator = User.objects.create(
+        email="creator@example.com",
+        username="creator",
+        first_name="c",
+        last_name="u",
+    )
+    category = IncidentCategory.objects.first()
+    if category is None:
+        group = Group.objects.first() or Group.objects.create(
+            name="Default Group", description="grp", order=0
+        )
+        category = IncidentCategory.objects.create(
+            name="Default Category", description="", order=0, group=group
+        )
+    incident = Incident.objects.create(
+        title="inc",
+        description="desc",
+        priority=Priority.get_default(),
+        incident_category=category,
+        environment=Environment.get_default(),
+        created_by=creator,
+    )
+    incident.create_incident_update = MagicMock()
+    return incident
+
+
+def _run_webhook(incident: Incident, change_item: dict) -> None:
+    payload = {
+        "issue": {"id": "123", "key": "IMPACT-1"},
+        "changelog": {"items": [change_item]},
+        "user": {"displayName": "jira-user"},
+        "webhookEvent": "jira:issue_updated",
+    }
+    mock_ticket = SimpleNamespace(incident=incident)
+    fake_qs = SimpleNamespace(get=lambda **kwargs: mock_ticket)
+    with patch(
+        "firefighter.raid.serializers.JiraTicket.objects.select_related",
+        return_value=fake_qs,
+    ):
+        serializer = JiraWebhookUpdateSerializer(data=payload)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+
+@pytest.mark.django_db
+def test_story_points_change_does_not_flip_priority() -> None:
+    """Regression: a Story Points change (customfield_10008) whose value is 1-5 must
+    NOT be misread as a priority change. This is the AFP-4216 bug (Story Points=2
+    flipped the incident to P2)."""
+    incident = _make_incident()
+
+    _run_webhook(
+        incident,
+        {
+            "field": "Story Points",
+            "fieldId": "customfield_10008",
+            "fromString": None,
+            "toString": "2",
+        },
+    )
+
+    incident.create_incident_update.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_customfield_11064_change_syncs_priority() -> None:
+    """Jira → Impact: a real change of the FF priority field (customfield_11064)
+    must sync the incident priority with event_type=jira_priority_sync."""
+    Priority.objects.get_or_create(
+        value=2,
+        defaults={
+            "name": "P2",
+            "order": 2,
+            "description": "",
+            "needs_postmortem": True,
+        },
+    )
+    incident = _make_incident()
+
+    _run_webhook(
+        incident,
+        {
+            "field": "Priority",
+            "fieldId": "customfield_11064",
+            "fromString": "4",
+            "toString": "2",
+        },
+    )
+
+    incident.create_incident_update.assert_called_once()
+    kwargs = incident.create_incident_update.call_args.kwargs
+    assert kwargs["event_type"] == "jira_priority_sync"
+
+
+@pytest.mark.django_db
+def test_standard_priority_field_does_not_sync() -> None:
+    """Impact owns customfield_11064, not the standard Jira priority field. A change
+    of the standard `priority` field must NOT flip the incident (kills the historical
+    Resolution=Done -> Highest propagation vector)."""
+    incident = _make_incident()
+
+    _run_webhook(
+        incident,
+        {
+            "field": "priority",
+            "fieldId": "priority",
+            "fromString": "Medium",
+            "toString": "Highest",
+        },
+    )
+
+    incident.create_incident_update.assert_not_called()


### PR DESCRIPTION
## Problem

The Jira→Impact webhook handler (`JiraWebhookUpdateSerializer`) decided whether a changelog item was a **priority change by parsing its value** (`1-5` / `Highest..Lowest`), regardless of *which* Jira field actually changed.

As a result, **any** Jira field set to a value in that range was misread as a priority change and silently flipped the incident priority. The most common offender is **Story Points** (`customfield_10008`), whose values overlap the `1-5` priority range.

### Evidence (production audit, 2026-05-01 → 2026-06-02)

Reviewing the 8 `jira_priority_sync` events against the Jira changelog:

| Incident | Ticket | Synced → | Field that actually changed | Verdict |
|---|---|---|---|---|
| #14405 | AFP-4216 | **P2** | `Story Points` → 2 | 🔴 spurious |
| #14432 | AFP-4311 | **P1** | `Story Points` → 1 | 🔴 spurious |
| #14462 | PAYM-2840 | **P1** | standard `priority` Medium→Highest | ⚠️ wrong field |

AFP-4216 had no priority change at all in its Jira history — only a Story Points edit to `2`, which flipped the incident from P4 to P2.

## Fix

Detect a priority change **strictly on `fieldId == customfield_11064`** — the only priority field Impact reads from and writes to (Impact→Jira sync writes `customfield_11064` exclusively). The match is now on field identity, never on the value.

The standard Jira `priority` field is no longer treated as a priority source either, keeping the inbound sync symmetric with the outbound one and removing the unintended propagation path (e.g. a Jira automation toggling the standard priority on resolution).

## Tests

New `tests/test_raid/test_jira_priority_sync.py`:
- a Story Points change (value 1-5) does **not** flip the incident priority (regression for AFP-4216);
- a real `customfield_11064` change **does** sync (`event_type=jira_priority_sync`);
- a standard `priority` field change is **ignored**.

Full `test_raid` suite green, ruff + mypy clean.