### PR TITLE
fix(jira): stop routing incident tickets through Closed before Reporter validation

### DIFF
--- a/src/firefighter/jira_app/client.py
+++ b/src/firefighter/jira_app/client.py
@@ -108,17 +108,41 @@ class JiraClient:
         )
 
         if len(transitions_to_apply) == 0:
-            logger.info(f"Issue {issue_id} is already closed. Not closing again.")
+            if current_status_id == closed_state_id:
+                logger.info(
+                    f"Issue {issue_id} is already at target status "
+                    f"'{target_status_name}'. Nothing to do."
+                )
+            else:
+                logger.warning(
+                    f"No transition path found for issue {issue_id} from status "
+                    f"id={current_status_id} to target '{target_status_name}'. "
+                    f"Leaving issue unchanged."
+                )
+            return
 
-        # Apply transitions
-        # XXX Better error handling
+        # Apply transitions sequentially. A screen on a transition is fine as long
+        # as it has no required field (we submit an empty field set). If a transition
+        # ever fails (e.g. a field was later made required), stop and surface the
+        # error rather than leaving the issue half-transitioned.
         for transition in transitions_to_apply:
             logger.debug(f"Running transition: {transition}")
-            self.jira.transition_issue(
-                issue=issue_id,
-                transition=transition,
-                fields={},
-            )
+            try:
+                self.jira.transition_issue(
+                    issue=issue_id,
+                    transition=transition,
+                    fields={},
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to apply transition '%s' on issue %s while moving to "
+                    "'%s'. Aborting remaining transitions; issue may be partially "
+                    "transitioned.",
+                    transition,
+                    issue_id,
+                    target_status_name,
+                )
+                raise
 
     def _fetch_jira_user(self, username: str) -> JiraAPIUser:
         """Fetches a Jira user from the Jira API.
@@ -404,12 +428,17 @@ class JiraClient:
 
         for transition in transitions:
             if "screen_name" in transition:
+                # A screen does NOT make a transition unusable over the API: it
+                # only fails if the screen has a *required* field (we submit an
+                # empty field set). Keeping screened transitions in the graph
+                # avoids the path-finder being forced onto undesirable detours
+                # to reach statuses whose only direct transitions are screened
+                # (e.g. "Reporter validation" -> see GT-2184).
                 logger.debug(
-                    "Ignoring Transition %s has a screen_name: %s",
+                    "Including Transition %s despite screen_name: %s",
                     transition["name"],
                     transition["screen_name"],
                 )
-                continue  # Ignore transitions that have a screen_name
             if transition["initial"]:
                 logger.debug(f"Ignoring Transition {transition['name']} is initial")
                 continue

--- a/src/firefighter/jira_app/utils.py
+++ b/src/firefighter/jira_app/utils.py
@@ -20,9 +20,20 @@ T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
+# Terminal statuses that must never be used as an *intermediate* hop when
+# computing a transition path. They remain valid as an explicit target (e.g.
+# closing an incident), but the path-finder must not route *through* them to
+# reach a non-terminal status. Without this guard, the only screen-free way to
+# reach "Reporter validation" in the incident workflow is via "Closed", which
+# transiently marks the ticket as Done on mitigation (see GT-2184).
+TERMINAL_STATUS_NAMES: Final[frozenset[str]] = frozenset({"Closed"})
+
 
 def _transition_path[T](
-    statuses_transitions: dict[T, set[T]], from_state: T, to_state: T
+    statuses_transitions: dict[T, set[T]],
+    from_state: T,
+    to_state: T,
+    blocked_states: set[T] | None = None,
 ) -> list[T]:
     """Returns the path to transition from one status to another.
         Includes the from_state and to_state.
@@ -33,12 +44,18 @@ def _transition_path[T](
         statuses_transitions (dict[T, set[T]]): dict of statuses and their targets
         from_state (T): starting status
         to_state (T): ending status
+        blocked_states (set[T] | None): statuses that must not be used as
+            intermediate hops. The from_state and to_state are never blocked, so
+            leaving a blocked status or targeting it directly still works.
 
     Returns:
         list[T]: list of statuses to transition from from_state to to_state
     """
     if from_state == to_state:
         return []
+    blocked = set(blocked_states or ())
+    blocked.discard(from_state)
+    blocked.discard(to_state)
     visited = set()
     queue = [[from_state]]
     while queue:
@@ -47,6 +64,8 @@ def _transition_path[T](
         if node not in visited:
             visited.add(node)
             for adjacent in statuses_transitions.get(node, []):
+                if adjacent in blocked:
+                    continue
                 new_path = list(path)
                 new_path.append(adjacent)
                 queue.append(new_path)
@@ -70,12 +89,26 @@ def get_transitions_to_apply(
     current_status_id: _StatusId,
     transitions_info: list[StatusTransitionInfo],
     closed_state_id: _StatusId,
+    terminal_status_names: frozenset[str] = TERMINAL_STATUS_NAMES,
 ) -> list[_StatusName]:
-    # Get path to closed state
+    # Get path to target state
     statuses_targets: dict[_StatusId, set[_TargetStatusId]] = {
         k["status_id"]: k["target_statuses"] for k in transitions_info
     }
-    path_states = _transition_path(statuses_targets, current_status_id, closed_state_id)
+    # Identify terminal statuses (e.g. "Closed") by name so the path-finder never
+    # routes *through* them to reach a non-terminal target. The target itself is
+    # exempt (handled in _transition_path), so closing an issue still works.
+    blocked_states: set[_StatusId] = {
+        k["status_id"]
+        for k in transitions_info
+        if k["status_name"] in terminal_status_names
+    }
+    path_states = _transition_path(
+        statuses_targets,
+        current_status_id,
+        closed_state_id,
+        blocked_states=blocked_states,
+    )
 
     # Get transitions to apply from path
     statuses_transitions_names: dict[

--- a/tests/test_raid/test_raid_transitions.py
+++ b/tests/test_raid/test_raid_transitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from firefighter.jira_app.client import JiraClient
 from firefighter.jira_app.types import StatusTransitionInfo
 from firefighter.jira_app.utils import (
     _states_to_transitions_names,
@@ -143,3 +144,218 @@ def test__get_status_id_from_name() -> None:
 
     # Test if function returns None for a non-existent status_name
     assert get_status_id_from_name(transitions_info, "NonExistent") is None
+
+
+# --- GT-2184: path-finder must not detour through terminal statuses ---------
+
+# Status ids mirroring the live "Incident workflow - v2023.03.13".
+_INCOMING = 1
+_IN_PROGRESS = 3
+_CLOSED = 6
+_CODE_REVIEW = 10300
+_PENDING = 10873
+_REPORTER_VALIDATION = 10874
+
+
+def _incident_workflow_transitions() -> list[StatusTransitionInfo]:
+    """Subset of the real incident workflow, with screened transitions INCLUDED
+    (matching the post-fix `_get_transitions` behaviour). The only direct
+    transitions into "Reporter validation" are screened ("Complete resolution",
+    "Reject"); the only screen-free entry is "Cancel validation" from "Closed".
+    """
+    return [
+        StatusTransitionInfo(
+            status_id=_INCOMING,
+            status_name="Incoming",
+            target_statuses={_PENDING, _REPORTER_VALIDATION, _CODE_REVIEW},
+            transition_to_status={
+                _PENDING: "Route",
+                _REPORTER_VALIDATION: "Reject",
+                _CODE_REVIEW: "Code Review",
+            },
+        ),
+        StatusTransitionInfo(
+            status_id=_IN_PROGRESS,
+            status_name="in progress",
+            target_statuses={_PENDING, _REPORTER_VALIDATION, _CODE_REVIEW},
+            transition_to_status={
+                _PENDING: "Cancel resolution",
+                _REPORTER_VALIDATION: "Complete resolution",
+                _CODE_REVIEW: "Code Review",
+            },
+        ),
+        StatusTransitionInfo(
+            status_id=_CODE_REVIEW,
+            status_name="Code Review",
+            target_statuses={_IN_PROGRESS, _CLOSED, _REPORTER_VALIDATION},
+            transition_to_status={
+                _IN_PROGRESS: "Go back to resolution",
+                _CLOSED: "Validate",
+                _REPORTER_VALIDATION: "Complete resolution",
+            },
+        ),
+        StatusTransitionInfo(
+            status_id=_PENDING,
+            status_name="Pending resolution",
+            target_statuses={_INCOMING, _IN_PROGRESS, _REPORTER_VALIDATION},
+            transition_to_status={
+                _INCOMING: "Cancel routing",
+                _IN_PROGRESS: "Start resolution",
+                _REPORTER_VALIDATION: "Reject",
+            },
+        ),
+        StatusTransitionInfo(
+            status_id=_REPORTER_VALIDATION,
+            status_name="Reporter validation",
+            target_statuses={_CLOSED, _IN_PROGRESS, _INCOMING},
+            transition_to_status={
+                _CLOSED: "Validate",
+                _IN_PROGRESS: "Go back to resolution",
+                _INCOMING: "Go back to incoming",
+            },
+        ),
+        StatusTransitionInfo(
+            status_id=_CLOSED,
+            status_name="Closed",
+            target_statuses={_REPORTER_VALIDATION, _PENDING},
+            transition_to_status={
+                _REPORTER_VALIDATION: "Cancel validation",
+                _PENDING: "Reopen",
+            },
+        ),
+    ]
+
+
+def test__transition_path_does_not_traverse_blocked_intermediate() -> None:
+    # 1 -> 2 -> 3, where 2 is terminal. Blocking 2 as an intermediate makes 3
+    # unreachable, instead of detouring through it.
+    graph: dict[int, set[int]] = {1: {2}, 2: {3}, 3: set()}
+
+    assert _transition_path(graph, 1, 3) == [1, 2, 3]
+    assert _transition_path(graph, 1, 3, blocked_states={2}) == []
+    # The target itself may be a blocked status (e.g. closing an issue).
+    assert _transition_path(graph, 1, 2, blocked_states={2}) == [1, 2]
+    # Leaving a blocked start status is allowed.
+    assert _transition_path(graph, 2, 3, blocked_states={2}) == [2, 3]
+
+
+def test_path_to_reporter_validation_is_direct_and_skips_closed() -> None:
+    info = _incident_workflow_transitions()
+    reporter_validation = get_status_id_from_name(info, "Reporter validation")
+    assert reporter_validation is not None
+
+    transitions = get_transitions_to_apply(_IN_PROGRESS, info, reporter_validation)
+
+    # Direct one-hop transition via the (screened-but-usable) "Complete resolution",
+    # never routing through "Closed".
+    assert transitions == ["Complete resolution"]
+
+
+def test_path_to_reporter_validation_never_routes_through_closed() -> None:
+    # Simulate a workflow where the only entry into "Reporter validation" is via
+    # "Closed" (Cancel validation). The terminal guard must refuse the detour and
+    # return no path, rather than transiently closing the ticket.
+    info = _incident_workflow_transitions()
+    for transition_info in info:
+        if transition_info["status_name"] != "Closed":
+            transition_info["target_statuses"].discard(_REPORTER_VALIDATION)
+            transition_info["transition_to_status"].pop(_REPORTER_VALIDATION, None)
+
+    reporter_validation = get_status_id_from_name(info, "Reporter validation")
+    assert reporter_validation is not None
+
+    transitions = get_transitions_to_apply(_IN_PROGRESS, info, reporter_validation)
+
+    assert transitions == []
+
+
+def test_closing_still_reaches_closed_when_it_is_the_target() -> None:
+    info = _incident_workflow_transitions()
+    closed = get_status_id_from_name(info, "Closed")
+    assert closed is not None
+
+    transitions = get_transitions_to_apply(_IN_PROGRESS, info, closed)
+
+    # "Closed" is the explicit target, so it is reachable despite being terminal.
+    # The final hop into "Closed" is the "Validate" transition.
+    assert transitions
+    assert transitions[-1] == "Validate"
+
+
+def test__get_transitions_keeps_screened_transitions() -> None:
+    # Regression for GT-2184: a transition with a screen must NOT be dropped from
+    # the graph. It is usable over the API as long as its screen has no required
+    # field (FF submits an empty field set). Before the fix, _get_transitions
+    # discarded every screened transition, leaving "Reporter validation"
+    # reachable only via "Closed".
+    workflow = {
+        "statuses": [
+            {
+                "step_id": _IN_PROGRESS,
+                "status_id": _IN_PROGRESS,
+                "name": "in progress",
+                "initial": False,
+            },
+            {
+                "step_id": _REPORTER_VALIDATION,
+                "status_id": _REPORTER_VALIDATION,
+                "name": "Reporter validation",
+                "initial": False,
+            },
+        ],
+        "transitions": [
+            {
+                "source_id": _IN_PROGRESS,
+                "target_id": _REPORTER_VALIDATION,
+                "name": "Complete resolution",
+                "initial": False,
+                "global_transition": False,
+                "screen_name": "IM: Resolution screen",
+            },
+        ],
+    }
+
+    transitions_info = JiraClient._get_transitions(workflow)  # type: ignore[arg-type]
+
+    in_progress = next(
+        t for t in transitions_info if t["status_id"] == _IN_PROGRESS
+    )
+    assert _REPORTER_VALIDATION in in_progress["target_statuses"]
+    assert (
+        in_progress["transition_to_status"][_REPORTER_VALIDATION]
+        == "Complete resolution"
+    )
+
+
+def test__get_transitions_still_drops_initial_transitions() -> None:
+    # The "initial" transition (issue creation) must still be excluded — only the
+    # screen filter was relaxed.
+    workflow = {
+        "statuses": [
+            {
+                "step_id": _IN_PROGRESS,
+                "status_id": _IN_PROGRESS,
+                "name": "in progress",
+                "initial": False,
+            },
+            {
+                "step_id": _REPORTER_VALIDATION,
+                "status_id": _REPORTER_VALIDATION,
+                "name": "Reporter validation",
+                "initial": False,
+            },
+        ],
+        "transitions": [
+            {
+                "source_id": _IN_PROGRESS,
+                "target_id": _REPORTER_VALIDATION,
+                "name": "Create",
+                "initial": True,
+                "global_transition": False,
+            },
+        ],
+    }
+
+    transitions_info = JiraClient._get_transitions(workflow)  # type: ignore[arg-type]
+
+    assert transitions_info == []


### PR DESCRIPTION
## Summary

FireFighter's JIRA transition path-finder dropped every *screened* transition, which left **Reporter validation** reachable only via the terminal **Closed** status. On mitigation this transiently set incident tickets to *Closed* before moving them to *Reporter validation* — visible as spurious transitions in the issue history.

Ref: GT-2184

## Root cause

- `_get_transitions` skips any transition that has a screen. In `Incident workflow - v2023.03.13`, every direct transition into *Reporter validation* (`Complete resolution`, `Reject`) has a screen, so FF discards them. The only screen-free entry is `Closed → Reporter validation` (`Cancel validation`), forcing the BFS onto `… → Code Review → Closed → Reporter validation`.
- Verified via the JIRA API that those screens carry **only optional fields**, so calling them with an empty payload (what FF already submits) is safe. The same workflow + behavior was confirmed across the `T2`, `INCIDENT`, and `GT` projects.

## Changes

- **`jira_app/client.py` `_get_transitions`** — keep screened transitions in the graph (a screen only blocks the API call when it has a *required* field; FF submits an empty field set). Surfaces the direct `in progress → Reporter validation` edge.
- **`jira_app/utils.py`** — `_transition_path` gains a `blocked_states` parameter; `get_transitions_to_apply` blocks terminal statuses (`TERMINAL_STATUS_NAMES = {"Closed"}`) as *intermediate* hops only. The target itself stays exempt, so closing an incident still works.
- **`jira_app/client.py` `transition_issue_auto`** — distinguish "already at target" from "no path found", and halt with a clear log if a transition fails instead of leaving the issue half-transitioned.
- **Tests** — `tests/test_raid/test_raid_transitions.py`: +6 tests covering screened-transition inclusion, the no-`Closed`-detour guard, closing still reaching `Closed`, and the terminal-intermediate guard.

## How to test

```
pdm run tests   # tests/test_raid/test_raid_transitions.py -> 10 passed
```
`mypy` and `ruff` clean on all changed files.

## Notes for reviewer

- The fix assumes the per-issue `hasScreen: true` flag is equivalent to the workflow-builder endpoint's `screen_name` field that `_get_transitions` reads. This is almost certainly true but was not directly verifiable via the API used during investigation — worth a quick confirm by someone with JIRA workflow-admin access before merge.
