### PR TITLE
fix(jira): ignore self-authored webhooks in JIRA->Impact reverse sync (GT-2184)

### DIFF
--- a/src/firefighter/raid/serializers.py
+++ b/src/firefighter/raid/serializers.py
@@ -448,7 +448,23 @@ class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
     ) -> bool:
         field = (change_item.get("field") or "").lower()
 
-        # Loop prevention: skip if this exact change was just sent Impact -> Jira
+        # Loop prevention (primary): skip changes FireFighter itself made in Jira.
+        # FF performs every Jira write as a single service account; reflecting its
+        # own changes back into Impact bounces the incident's status — e.g. the
+        # transient "Pending resolution" hop of FF's own transition maps back to
+        # OPEN and regresses a Mitigated incident (see GT-2184 / INCIDENT-27620).
+        # The reverse sync must only mirror human/external Jira changes.
+        if self._is_authored_by_ff(validated_data):
+            logger.debug(
+                "Skipping Jira→Impact sync for '%s' on %s: change authored by the "
+                "FireFighter service account",
+                field,
+                jira_ticket_key,
+            )
+            return False
+
+        # Loop prevention (fallback): skip if this exact change was just sent
+        # Impact -> Jira. Kept as belt-and-suspenders behind the actor check above.
         if self._skip_due_to_recent_impact_change(jira_ticket_key, field, change_item):
             logger.debug(
                 "Skipping Jira→Impact sync for %s on %s due to recent Impact change",
@@ -610,6 +626,21 @@ class JiraWebhookUpdateSerializer(serializers.Serializer[Any]):
             event_type="jira_priority_sync",
         )
         return True
+
+    @staticmethod
+    def _is_authored_by_ff(validated_data: dict[str, Any]) -> bool:
+        """Whether the webhook was triggered by FireFighter's own Jira account.
+
+        FF performs all Jira writes (issue creation and status/priority
+        transitions) as a single service account, identified by
+        ``RAID_DEFAULT_JIRA_QRAFT_USER_ID``. Changes authored by that account are
+        echoes of Impact→Jira sync and must never be reflected back into Impact.
+        """
+        ff_account_id = getattr(settings, "RAID_DEFAULT_JIRA_QRAFT_USER_ID", "") or ""
+        if not ff_account_id:
+            return False
+        actor = validated_data.get("user") or {}
+        return actor.get("accountId") == ff_account_id
 
     @staticmethod
     def _skip_due_to_recent_impact_change(

--- a/tests/test_raid/test_jira_status_sync.py
+++ b/tests/test_raid/test_jira_status_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -144,6 +145,74 @@ def test_signal_transitions_non_close_status(mocker) -> None:
             mocker.call("123", "Pending resolution", mocker.ANY),
             mocker.call("123", "in progress", mocker.ANY),
         ]
+    )
+
+
+def _run_status_webhook(incident: Any, *, to_status: str, actor_account_id: str) -> None:
+    webhook_payload = {
+        "issue": {"id": "123", "key": "IMPACT-1"},
+        "changelog": {
+            "items": [
+                {
+                    "field": "status",
+                    "fromString": "in progress",
+                    "toString": to_status,
+                }
+            ]
+        },
+        "user": {"displayName": "actor", "accountId": actor_account_id},
+        "webhookEvent": "jira:issue_updated",
+    }
+    mock_ticket = SimpleNamespace(incident=incident)
+    fake_qs = SimpleNamespace(get=lambda **kwargs: mock_ticket)
+    with patch(
+        "firefighter.raid.serializers.JiraTicket.objects.select_related",
+        return_value=fake_qs,
+    ):
+        serializer = JiraWebhookUpdateSerializer(data=webhook_payload)
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+
+@override_settings(RAID_DEFAULT_JIRA_QRAFT_USER_ID="ff-bot-account-id")
+def test_jira_webhook_skips_status_change_authored_by_ff() -> None:
+    """Jira → Impact: a status change authored by FireFighter's own service account
+    must NOT sync back. This is the self-induced bounce: FF's own transition through
+    the transient "Pending resolution" hop maps to OPEN and would regress the
+    incident (see GT-2184 / INCIDENT-27620).
+    """
+    incident = SimpleNamespace(create_incident_update=MagicMock())
+
+    _run_status_webhook(
+        incident,
+        to_status="Pending resolution",
+        actor_account_id="ff-bot-account-id",
+    )
+
+    incident.create_incident_update.assert_not_called()
+
+
+@override_settings(RAID_DEFAULT_JIRA_QRAFT_USER_ID="ff-bot-account-id")
+def test_jira_webhook_syncs_status_change_authored_by_human() -> None:
+    """Jira → Impact: a status change authored by a human (different account) still
+    syncs — the actor filter must not over-suppress genuine external changes.
+    """
+    incident = SimpleNamespace(
+        id=1,
+        status=IncidentStatus.INVESTIGATING,
+        create_incident_update=MagicMock(),
+    )
+
+    _run_status_webhook(
+        incident,
+        to_status="Reporter validation",
+        actor_account_id="some-human-account-id",
+    )
+
+    incident.create_incident_update.assert_called_once()
+    assert (
+        incident.create_incident_update.call_args.kwargs["status"]
+        == IncidentStatus.MITIGATED
     )
 
 


### PR DESCRIPTION
## Summary

The JIRA→Impact reverse sync was reflecting back status/priority changes that **FireFighter itself made** (as its Jira service account). FF's own multi-step transitions pass through the transient **"Pending resolution"** hop, which the reverse map (`JIRA_TO_IMPACT_STATUS_MAP["Pending resolution"] = OPEN`) turns into **OPEN** — bouncing a **Mitigated** incident back to **Open**.

Ref: GT-2184 (observed on INCIDENT-27620 / post-mortem INCIDENT-27621)

## Root cause

From the live `INCIDENT-27620` changelog, **every** transition is authored by the FF bot (`team qraft`, `RAID_DEFAULT_JIRA_QRAFT_USER_ID`). At 11:17 the bot drove `in progress → Pending resolution → Code Review → Closed → Reporter validation`; the unguarded intermediate `Pending resolution` webhook synced back as `OPEN` and regressed the incident.

The existing loop guard (`_skip_due_to_recent_impact_change`) is a **single-use, TTL-bound cache key**, so it cannot reliably suppress the multiple / out-of-order `Pending resolution` webhooks FF emits during its own transitions.

## Fix

Skip the reverse sync for webhooks **authored by FF's own Jira account** (`RAID_DEFAULT_JIRA_QRAFT_USER_ID`). The reverse sync exists to mirror *human/external* Jira changes; FF's own changes are echoes and must never sync back. This deterministically breaks the self-induced loop regardless of status, timing, or hop count — and also covers the identical `"in progress" → MITIGATING` vulnerability. The cache guard is kept as a fallback.

- `serializers.py`: add `_is_authored_by_ff`, short-circuit `_sync_jira_fields_to_incident` for self-authored changes.
- Tests: a self-authored `Pending resolution` webhook is **not** synced (the exact bounce); a human-authored change still syncs (no over-suppression).

## Why this is correct (round-trip)

- **Change originates in Impact** → FF pushes to Jira *as `teamqraft`* → webhook author = `teamqraft` → **skipped**. Impact already holds the change; reflecting it back is the bounce. ✅
- **Change originates in Jira** (a human/dev edits the ticket) → webhook author = *that human's account* → **synced**. ✅

Human-in-Jira changes carry the human's own account, so they are never dropped. Dev sub-statuses (`Code Review`, `Deployed To INT/STG`) aren't in `JIRA_TO_IMPACT_STATUS_MAP`, so they're ignored regardless of author.

## How to test

`pdm run tests` → `tests/test_raid/test_jira_status_sync.py` (the two new `*_authored_by_*` tests). `mypy` + `ruff` clean. The actor-gate logic (`_is_authored_by_ff`) was unit-verified for bot / human / missing-actor / unconfigured cases.

## Relationship to #311

Complementary, independent change. #311 (transition path-finder) removes the *Closed-detour* that produced this specific bounce's intermediate webhooks; this PR fixes the reverse-sync **class** at its source (self-authored echoes). Either alone helps; together they close the loop.

## ⚠️ Reviewer must confirm: `teamqraft` is FireFighter-exclusive

The correctness of this fix reduces to a single assumption: **the `RAID_DEFAULT_JIRA_QRAFT_USER_ID` / `RAID_JIRA_API_USER` account (`teamqraft`) is used *only* by FireFighter.**

- FF authenticates to Jira with a single basic-auth API user — no OAuth/impersonation/run-as (`jira_app/client.py:64`). So every FF Jira write (creation, transitions, field updates) is authored by `teamqraft`, regardless of which human triggered it in Impact.
- Repo scan supports exclusivity: `teamqraft` appears only as FF's API user, default reporter fallback, and a former default watcher; a session note records it **has no Slack account** (it is a bot, not a human).
- **Not verifiable from the repo:** Jira-side **automation rules**, or a human operating the `teamqraft` account directly. If either transitions incident tickets as `teamqraft`, this fix would wrongly skip those — in that case, switch from an identity check to a **self-stamped marker** FF sets on its own transitions and recognises on the webhook.

If `teamqraft` is a dedicated FF service account (expected), this fix is robust as-is.
