### PR TITLE
feat(dust): Generate post-mortem with Dust button in Slack

### DIFF
--- a/docs/deploy/XX-settings.md
+++ b/docs/deploy/XX-settings.md
@@ -78,7 +78,7 @@ See [django-oauth2-codeflow](https://gitlab.com/systra/qeto/lib/django-oauth2-au
 
 ### Dust AI integration (optional)
 
-- [`DUST_ENABLED`][firefighter.firefighter.settings.components.slack.DUST_ENABLED]: set to `True` to show the "Generate post-mortem with Dust" button in Jira post-mortem Slack messages.
+- [`ENABLE_DUST`][firefighter.firefighter.settings.components.slack.ENABLE_DUST]: set to `True` to show the "Generate post-mortem with Dust" button in Jira post-mortem Slack messages.
 - [`DUST_SLACK_BOT_NAME`][firefighter.firefighter.settings.components.slack.DUST_SLACK_BOT_NAME]: Slack display name of the Dust app (default: `dust`). Used to resolve its user ID at runtime to invite it to the incident channel and mention it.
 
 ## Confluence integration

--- a/docs/deploy/XX-settings.md
+++ b/docs/deploy/XX-settings.md
@@ -76,6 +76,11 @@ See [django-oauth2-codeflow](https://gitlab.com/systra/qeto/lib/django-oauth2-au
 - [`SLACK_APP_EMOJI`][firefighter.firefighter.settings.components.slack.SLACK_APP_EMOJI]
 - [`FF_SLACK_SKIP_CHECKS`][firefighter.firefighter.settings.components.slack.FF_SLACK_SKIP_CHECKS]
 
+### Dust AI integration (optional)
+
+- [`DUST_ENABLED`][firefighter.firefighter.settings.components.slack.DUST_ENABLED]: set to `True` to show the "Generate post-mortem with Dust" button in Jira post-mortem Slack messages.
+- [`DUST_SLACK_BOT_NAME`][firefighter.firefighter.settings.components.slack.DUST_SLACK_BOT_NAME]: Slack display name of the Dust app (default: `dust`). Used to resolve its user ID at runtime to invite it to the incident channel and mention it.
+
 ## Confluence integration
 
 `ENABLE_CONFLUENCE`

--- a/src/firefighter/firefighter/settings/components/slack.py
+++ b/src/firefighter/firefighter/settings/components/slack.py
@@ -52,5 +52,7 @@ FF_SLACK_SKIP_CHECKS: bool = config(
 )
 """Skip Slack checks. Only use for testing or demo."""
 
-DUST_SLACK_BOT_USER_ID: str | None = config("DUST_SLACK_BOT_USER_ID", default=None)
-"""Slack member ID of the Dust bot (e.g. 'UXXXXXXXXX'). If set, enables the 'Generate post-mortem with Dust' button in incident Slack messages."""
+DUST_ENABLED: bool = config("DUST_ENABLED", cast=bool, default=False)
+"""Enable the 'Generate post-mortem with Dust' button in incident Slack messages."""
+DUST_SLACK_BOT_NAME: str = config("DUST_SLACK_BOT_NAME", default="dust")
+"""Slack display name of the Dust app (used to resolve its user ID at runtime)."""

--- a/src/firefighter/firefighter/settings/components/slack.py
+++ b/src/firefighter/firefighter/settings/components/slack.py
@@ -51,3 +51,6 @@ FF_SLACK_SKIP_CHECKS: bool = config(
     "FF_SLACK_SKIP_CHECKS", cast=bool, default=_is_default_skip_check_cmd
 )
 """Skip Slack checks. Only use for testing or demo."""
+
+DUST_SLACK_BOT_USER_ID: str | None = config("DUST_SLACK_BOT_USER_ID", default=None)
+"""Slack member ID of the Dust bot (e.g. 'UXXXXXXXXX'). If set, enables the 'Generate post-mortem with Dust' button in incident Slack messages."""

--- a/src/firefighter/firefighter/settings/components/slack.py
+++ b/src/firefighter/firefighter/settings/components/slack.py
@@ -52,7 +52,7 @@ FF_SLACK_SKIP_CHECKS: bool = config(
 )
 """Skip Slack checks. Only use for testing or demo."""
 
-DUST_ENABLED: bool = config("DUST_ENABLED", cast=bool, default=False)
+ENABLE_DUST: bool = config("ENABLE_DUST", cast=bool, default=False)
 """Enable the 'Generate post-mortem with Dust' button in incident Slack messages."""
 DUST_SLACK_BOT_NAME: str = config("DUST_SLACK_BOT_NAME", default="dust")
 """Slack display name of the Dust app (used to resolve its user ID at runtime)."""

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -675,7 +675,7 @@ class SlackMessageIncidentPostMortemCreated(SlackMessageSurface):
         parts = ["📔 The post-mortem has been created:"]
 
         # Add Confluence link if available
-        if hasattr(self.incident, "postmortem_for"):
+        if getattr(settings, "ENABLE_CONFLUENCE", False) and hasattr(self.incident, "postmortem_for"):
             parts.append(f"• Confluence: {self.incident.postmortem_for.page_url}")
 
         # Add Jira link if available
@@ -701,6 +701,18 @@ class SlackMessageIncidentPostMortemCreated(SlackMessageSurface):
                         url="https://manomano.atlassian.net/wiki/spaces/TC/pages/5639635000/How+to+fill+Post-Mortems+in+Jira",
                         value="jira_postmortem_documentation",
                         action_id="open_link",
+                    ),
+                )
+            )
+
+        if settings.DUST_SLACK_BOT_USER_ID:
+            blocks.append(
+                SectionBlock(
+                    text="Generate and update the post-mortem with Dust AI",
+                    accessory=ButtonElement(
+                        text="Generate post-mortem with Dust",
+                        value=str(self.incident.id),
+                        action_id="generate_dust_postmortem",
                     ),
                 )
             )

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -705,7 +705,7 @@ class SlackMessageIncidentPostMortemCreated(SlackMessageSurface):
                 )
             )
 
-        if getattr(settings, "DUST_ENABLED", False):
+        if getattr(settings, "ENABLE_DUST", False):
             blocks.append(
                 SectionBlock(
                     text="Generate and update the post-mortem with Dust AI",

--- a/src/firefighter/slack/messages/slack_messages.py
+++ b/src/firefighter/slack/messages/slack_messages.py
@@ -705,7 +705,7 @@ class SlackMessageIncidentPostMortemCreated(SlackMessageSurface):
                 )
             )
 
-        if settings.DUST_SLACK_BOT_USER_ID:
+        if getattr(settings, "DUST_ENABLED", False):
             blocks.append(
                 SectionBlock(
                     text="Generate and update the post-mortem with Dust AI",

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from celery import shared_task
+from django.conf import settings
+from slack_sdk.errors import SlackApiError
+
+from firefighter.slack.slack_app import DefaultWebClient, slack_client
+
+if TYPE_CHECKING:
+    from slack_sdk.web.client import WebClient
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    name="slack.generate_dust_postmortem",
+    autoretry_for=(SlackApiError,),
+    retry_kwargs={"max_retries": 2},
+    default_retry_delay=30,
+)
+@slack_client
+def generate_dust_postmortem(
+    incident_id: int,
+    client: WebClient = DefaultWebClient,
+) -> None:
+    from firefighter.incidents.models.incident import Incident
+
+    incident = Incident.objects.select_related("conversation").get(id=incident_id)
+    if not hasattr(incident, "conversation"):
+        logger.warning("Incident %s has no Slack channel, skipping Dust trigger", incident_id)
+        return
+
+    bot_user_id: str | None = settings.DUST_SLACK_BOT_USER_ID
+    if not bot_user_id:
+        logger.warning("DUST_SLACK_BOT_USER_ID not configured, skipping Dust trigger")
+        return
+
+    channel_id: str = incident.conversation.channel_id
+
+    try:
+        client.conversations_invite(channel=channel_id, users=[bot_user_id])
+        logger.info("Invited Dust bot %s to channel %s", bot_user_id, channel_id)
+    except SlackApiError as e:
+        if e.response.get("error") == "already_in_channel":
+            logger.info("Dust bot already in channel %s", channel_id)
+        else:
+            raise
+
+    client.chat_postMessage(
+        channel=channel_id,
+        text=f"<@{bot_user_id}> @IncidentManagementPostMortem",
+    )
+    logger.info("Sent Dust post-mortem generation request for incident %s", incident_id)

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -15,6 +15,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
+    """Find the Slack user ID of a bot app by its display name."""
+    cursor = None
+    while True:
+        kwargs: dict = {"limit": 200}
+        if cursor:
+            kwargs["cursor"] = cursor
+        response = client.users_list(**kwargs)
+        for member in response.get("members", []):
+            if member.get("is_bot") and member.get("name") == bot_name:
+                return member["id"]
+        cursor = response.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            break
+    return None
+
+
 @shared_task(
     name="slack.generate_dust_postmortem",
     autoretry_for=(SlackApiError,),
@@ -33,9 +50,10 @@ def generate_dust_postmortem(
         logger.warning("Incident %s has no Slack channel, skipping Dust trigger", incident_id)
         return
 
-    bot_user_id: str | None = settings.DUST_SLACK_BOT_USER_ID
+    bot_name: str = settings.DUST_SLACK_BOT_NAME
+    bot_user_id = _resolve_bot_user_id(client, bot_name)
     if not bot_user_id:
-        logger.warning("DUST_SLACK_BOT_USER_ID not configured, skipping Dust trigger")
+        logger.warning("Dust bot '%s' not found in workspace, skipping Dust trigger", bot_name)
         return
 
     channel_id: str = incident.conversation.channel_id

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -51,6 +51,6 @@ def generate_dust_postmortem(
 
     client.chat_postMessage(
         channel=channel_id,
-        text=f"<@{bot_user_id}> @IncidentManagementPostMortem",
+        text=f"<@{bot_user_id}> ~IncidentManagementPostMortem",
     )
     logger.info("Sent Dust post-mortem generation request for incident %s", incident_id)

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from celery import shared_task
 from django.conf import settings
@@ -19,14 +19,16 @@ def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
     """Find the Slack user ID of a bot app by its display name."""
     cursor = None
     while True:
-        kwargs: dict = {"limit": 200}
+        kwargs: dict[str, Any] = {"limit": 200}
         if cursor:
             kwargs["cursor"] = cursor
         response = client.users_list(**kwargs)
-        for member in response.get("members", []):
+        members: list[dict[str, Any]] = response.get("members") or []
+        for member in members:
             if member.get("is_bot") and member.get("name") == bot_name:
                 return member["id"]
-        cursor = response.get("response_metadata", {}).get("next_cursor")
+        response_metadata: dict[str, Any] = response.get("response_metadata") or {}
+        cursor = response_metadata.get("next_cursor")
         if not cursor:
             break
     return None

--- a/src/firefighter/slack/views/events/actions_and_shortcuts.py
+++ b/src/firefighter/slack/views/events/actions_and_shortcuts.py
@@ -49,3 +49,14 @@ def update_update_modal(ack: Ack, body: dict[str, Any]) -> None:
 def open_link(ack: Ack) -> None:
     """Does nothing. ack() is mandatory, even on buttons that open a URL."""
     ack()
+
+
+@app.action("generate_dust_postmortem")
+def generate_dust_postmortem_action(ack: Ack, body: dict[str, Any]) -> None:
+    ack()
+    incident_id = int(body["actions"][0]["value"])
+    from firefighter.slack.tasks.generate_dust_postmortem import (
+        generate_dust_postmortem,
+    )
+
+    generate_dust_postmortem.delay(incident_id)

--- a/tests/test_slack/test_action_generate_dust_postmortem.py
+++ b/tests/test_slack/test_action_generate_dust_postmortem.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_action_acks_and_dispatches_task() -> None:
+    """Handler acks immediately then dispatches the Celery task with the incident_id."""
+    from firefighter.slack.views.events.actions_and_shortcuts import (
+        generate_dust_postmortem_action,
+    )
+
+    ack = MagicMock()
+    body = {"actions": [{"value": "42"}]}
+
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem.generate_dust_postmortem.delay"
+    ) as mock_delay:
+        generate_dust_postmortem_action(ack=ack, body=body)
+
+    ack.assert_called_once()
+    mock_delay.assert_called_once_with(42)

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.slack.factories import IncidentChannelFactory
+from firefighter.slack.tasks.generate_dust_postmortem import generate_dust_postmortem
+
+
+def _make_incident_with_channel() -> object:
+    user = UserFactory.build()
+    user.save()
+    incident = IncidentFactory.build(created_by=user)
+    incident.save()
+    channel = IncidentChannelFactory.build(incident=incident)
+    channel.save()
+    incident.refresh_from_db()
+    return incident
+
+
+def _make_incident_without_channel() -> object:
+    user = UserFactory.build()
+    user.save()
+    incident = IncidentFactory.build(created_by=user)
+    incident.save()
+    return incident
+
+
+@pytest.mark.django_db
+def test_invites_bot_and_posts_message(settings) -> None:
+    """Happy path: invites bot then posts the generation request."""
+    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    incident = _make_incident_with_channel()
+    channel_id = incident.conversation.channel_id
+
+    mock_client = MagicMock()
+    mock_client.conversations_invite.return_value = {"ok": True}
+    mock_client.chat_postMessage.return_value = {"ok": True}
+
+    generate_dust_postmortem(incident.id, client=mock_client)
+
+    mock_client.conversations_invite.assert_called_once_with(
+        channel=channel_id, users=["UDUSTBOT1"]
+    )
+    call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+    assert call_kwargs["channel"] == channel_id
+    assert "UDUSTBOT1" in call_kwargs["text"]
+
+
+@pytest.mark.django_db
+def test_already_in_channel_is_tolerated(settings) -> None:
+    """If bot is already in channel, skip invite silently and still post message."""
+    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    incident = _make_incident_with_channel()
+
+    mock_client = MagicMock()
+    mock_client.conversations_invite.side_effect = SlackApiError(
+        "already_in_channel", {"ok": False, "error": "already_in_channel"}
+    )
+    mock_client.chat_postMessage.return_value = {"ok": True}
+
+    generate_dust_postmortem(incident.id, client=mock_client)
+
+    mock_client.chat_postMessage.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_skips_when_no_conversation(settings) -> None:
+    """If the incident has no Slack channel, do nothing."""
+    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    incident = _make_incident_without_channel()
+
+    mock_client = MagicMock()
+
+    generate_dust_postmortem(incident.id, client=mock_client)
+
+    mock_client.conversations_invite.assert_not_called()
+    mock_client.chat_postMessage.assert_not_called()

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from slack_sdk.errors import SlackApiError
@@ -31,8 +31,8 @@ def _make_incident_without_channel() -> object:
 
 @pytest.mark.django_db
 def test_invites_bot_and_posts_message(settings) -> None:
-    """Happy path: invites bot then posts the generation request."""
-    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    """Happy path: resolves bot user ID, invites bot then posts the generation request."""
+    settings.DUST_SLACK_BOT_NAME = "dust"
     incident = _make_incident_with_channel()
     channel_id = incident.conversation.channel_id
 
@@ -40,7 +40,11 @@ def test_invites_bot_and_posts_message(settings) -> None:
     mock_client.conversations_invite.return_value = {"ok": True}
     mock_client.chat_postMessage.return_value = {"ok": True}
 
-    generate_dust_postmortem(incident.id, client=mock_client)
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+        return_value="UDUSTBOT1",
+    ):
+        generate_dust_postmortem(incident.id, client=mock_client)
 
     mock_client.conversations_invite.assert_called_once_with(
         channel=channel_id, users=["UDUSTBOT1"]
@@ -54,7 +58,7 @@ def test_invites_bot_and_posts_message(settings) -> None:
 @pytest.mark.django_db
 def test_already_in_channel_is_tolerated(settings) -> None:
     """If bot is already in channel, skip invite silently and still post message."""
-    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    settings.DUST_SLACK_BOT_NAME = "dust"
     incident = _make_incident_with_channel()
 
     mock_client = MagicMock()
@@ -63,7 +67,11 @@ def test_already_in_channel_is_tolerated(settings) -> None:
     )
     mock_client.chat_postMessage.return_value = {"ok": True}
 
-    generate_dust_postmortem(incident.id, client=mock_client)
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+        return_value="UDUSTBOT1",
+    ):
+        generate_dust_postmortem(incident.id, client=mock_client)
 
     mock_client.chat_postMessage.assert_called_once()
 
@@ -71,12 +79,30 @@ def test_already_in_channel_is_tolerated(settings) -> None:
 @pytest.mark.django_db
 def test_skips_when_no_conversation(settings) -> None:
     """If the incident has no Slack channel, do nothing."""
-    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    settings.DUST_SLACK_BOT_NAME = "dust"
     incident = _make_incident_without_channel()
 
     mock_client = MagicMock()
 
     generate_dust_postmortem(incident.id, client=mock_client)
+
+    mock_client.conversations_invite.assert_not_called()
+    mock_client.chat_postMessage.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_skips_when_bot_not_found(settings) -> None:
+    """If the Dust bot is not found in the workspace, do nothing."""
+    settings.DUST_SLACK_BOT_NAME = "dust"
+    incident = _make_incident_with_channel()
+
+    mock_client = MagicMock()
+
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+        return_value=None,
+    ):
+        generate_dust_postmortem(incident.id, client=mock_client)
 
     mock_client.conversations_invite.assert_not_called()
     mock_client.chat_postMessage.assert_not_called()

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -48,6 +48,7 @@ def test_invites_bot_and_posts_message(settings) -> None:
     call_kwargs = mock_client.chat_postMessage.call_args.kwargs
     assert call_kwargs["channel"] == channel_id
     assert "UDUSTBOT1" in call_kwargs["text"]
+    assert "~IncidentManagementPostMortem" in call_kwargs["text"]
 
 
 @pytest.mark.django_db

--- a/tests/test_slack/test_slack_messages_postmortem_dust.py
+++ b/tests/test_slack/test_slack_messages_postmortem_dust.py
@@ -37,8 +37,8 @@ def _get_button_action_ids(blocks: list) -> list[str]:
 
 @pytest.mark.django_db
 def test_dust_button_present_when_enabled(settings) -> None:
-    """Button appears when DUST_ENABLED is True and JIRA post-mortem exists."""
-    settings.DUST_ENABLED = True
+    """Button appears when ENABLE_DUST is True and JIRA post-mortem exists."""
+    settings.ENABLE_DUST = True
     incident = _make_incident_with_jira_pm()
 
     msg = SlackMessageIncidentPostMortemCreated(incident)
@@ -58,8 +58,8 @@ def test_dust_button_present_when_enabled(settings) -> None:
 
 @pytest.mark.django_db
 def test_dust_button_absent_when_disabled(settings) -> None:
-    """Button is absent when DUST_ENABLED is False (default)."""
-    settings.DUST_ENABLED = False
+    """Button is absent when ENABLE_DUST is False (default)."""
+    settings.ENABLE_DUST = False
     incident = _make_incident_with_jira_pm()
 
     msg = SlackMessageIncidentPostMortemCreated(incident)

--- a/tests/test_slack/test_slack_messages_postmortem_dust.py
+++ b/tests/test_slack/test_slack_messages_postmortem_dust.py
@@ -36,9 +36,9 @@ def _get_button_action_ids(blocks: list) -> list[str]:
 
 
 @pytest.mark.django_db
-def test_dust_button_present_when_setting_configured(settings) -> None:
-    """Button appears when DUST_SLACK_BOT_USER_ID is set and JIRA post-mortem exists."""
-    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+def test_dust_button_present_when_enabled(settings) -> None:
+    """Button appears when DUST_ENABLED is True and JIRA post-mortem exists."""
+    settings.DUST_ENABLED = True
     incident = _make_incident_with_jira_pm()
 
     msg = SlackMessageIncidentPostMortemCreated(incident)
@@ -57,9 +57,9 @@ def test_dust_button_present_when_setting_configured(settings) -> None:
 
 
 @pytest.mark.django_db
-def test_dust_button_absent_when_setting_not_configured(settings) -> None:
-    """Button is absent when DUST_SLACK_BOT_USER_ID is not set."""
-    settings.DUST_SLACK_BOT_USER_ID = None
+def test_dust_button_absent_when_disabled(settings) -> None:
+    """Button is absent when DUST_ENABLED is False (default)."""
+    settings.DUST_ENABLED = False
     incident = _make_incident_with_jira_pm()
 
     msg = SlackMessageIncidentPostMortemCreated(incident)

--- a/tests/test_slack/test_slack_messages_postmortem_dust.py
+++ b/tests/test_slack/test_slack_messages_postmortem_dust.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from slack_sdk.models.blocks.block_elements import ButtonElement
+from slack_sdk.models.blocks.blocks import SectionBlock
+
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.jira_app.models import JiraPostMortem
+from firefighter.slack.messages.slack_messages import (
+    SlackMessageIncidentPostMortemCreated,
+)
+
+
+def _make_incident_with_jira_pm() -> object:
+    user = UserFactory.build()
+    user.save()
+    incident = IncidentFactory.build(created_by=user)
+    incident.save()
+    JiraPostMortem.objects.create(
+        incident=incident,
+        jira_issue_key="INCIDENT-123",
+        jira_issue_id="10001",
+        created_by=user,
+    )
+    incident.refresh_from_db()
+    return incident
+
+
+def _get_button_action_ids(blocks: list) -> list[str]:
+    return [
+        block.accessory.action_id
+        for block in blocks
+        if isinstance(block, SectionBlock)
+        and isinstance(getattr(block, "accessory", None), ButtonElement)
+    ]
+
+
+@pytest.mark.django_db
+def test_dust_button_present_when_setting_configured(settings) -> None:
+    """Button appears when DUST_SLACK_BOT_USER_ID is set and JIRA post-mortem exists."""
+    settings.DUST_SLACK_BOT_USER_ID = "UDUSTBOT1"
+    incident = _make_incident_with_jira_pm()
+
+    msg = SlackMessageIncidentPostMortemCreated(incident)
+    blocks = msg.get_blocks()
+
+    action_ids = _get_button_action_ids(blocks)
+    assert "generate_dust_postmortem" in action_ids
+
+    dust_block = next(
+        b for b in blocks
+        if isinstance(b, SectionBlock)
+        and isinstance(getattr(b, "accessory", None), ButtonElement)
+        and b.accessory.action_id == "generate_dust_postmortem"
+    )
+    assert dust_block.accessory.value == str(incident.id)
+
+
+@pytest.mark.django_db
+def test_dust_button_absent_when_setting_not_configured(settings) -> None:
+    """Button is absent when DUST_SLACK_BOT_USER_ID is not set."""
+    settings.DUST_SLACK_BOT_USER_ID = None
+    incident = _make_incident_with_jira_pm()
+
+    msg = SlackMessageIncidentPostMortemCreated(incident)
+    blocks = msg.get_blocks()
+
+    action_ids = _get_button_action_ids(blocks)
+    assert "generate_dust_postmortem" not in action_ids


### PR DESCRIPTION
## Summary

- Adds a **"Generate post-mortem with Dust"** button to the Slack message FireFighter posts when a Jira post-mortem ticket is created
- On click: invites the Dust Slack app to the incident channel, then posts `@dust ~IncidentManagementPostMortem` to trigger the AI agent
- The Dust app is resolved by display name at runtime via `users.list()` — no hardcoded user ID needed
- Feature is gated behind `DUST_ENABLED=True` (off by default); bot name configurable via `DUST_SLACK_BOT_NAME` (default: `dust`)

## Changes

- `settings/components/slack.py`: new `DUST_ENABLED` + `DUST_SLACK_BOT_NAME` settings
- `slack/tasks/generate_dust_postmortem.py`: Celery task — resolves bot user ID, invites bot, posts agent trigger message
- `slack/messages/slack_messages.py`: button added to `SlackMessageIncidentPostMortemCreated`, guarded by `DUST_ENABLED`; also fixes a latent `UndefinedTable` bug in `get_text()` when Confluence is not installed
- `slack/views/events/actions_and_shortcuts.py`: `@app.action("generate_dust_postmortem")` handler
- `docs/deploy/XX-settings.md`: documents the two new settings
- 7 new tests covering happy path, already-in-channel, bot-not-found, no-channel, button presence/absence, and action handler

## Test plan

- [ ] Set `DUST_ENABLED=True` in env — button appears on next Jira post-mortem creation
- [ ] Click button — Dust bot gets invited to channel and posts `@dust ~IncidentManagementPostMortem`
- [ ] With `DUST_ENABLED=False` (default) — button does not appear
- [ ] `pdm run pytest tests/test_slack/test_generate_dust_postmortem_task.py tests/test_slack/test_slack_messages_postmortem_dust.py tests/test_slack/test_action_generate_dust_postmortem.py`