### PR TITLE
fix(dust): register generate_dust_postmortem task in Celery task discovery

### DIFF
--- a/src/firefighter/slack/tasks/__init__.py
+++ b/src/firefighter/slack/tasks/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from firefighter.slack.tasks import (
     fetch_conversations_members,
+    generate_dust_postmortem,
     send_message,
     send_postmortem_reminders,
     send_reminders,


### PR DESCRIPTION
## Summary

- Fixes `Received unregistered task of type 'slack.generate_dust_postmortem'` error on the Celery worker
- `generate_dust_postmortem` was missing from `slack/tasks/__init__.py`, so Celery never imported/registered it at startup
- One-line fix: add the module import alongside the other task modules

## Root cause

The task module `slack/tasks/generate_dust_postmortem.py` was created in #316 but not added to `slack/tasks/__init__.py`. Celery task autodiscovery relies on these imports to register tasks at worker startup — without it, the task is unknown to the worker and messages are discarded.