### PR TITLE
feat(api): idempotent incident creation via dedup_key

### DIFF
--- a/src/firefighter/api/serializers.py
+++ b/src/firefighter/api/serializers.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import EmailValidator
+from django.db import IntegrityError
 from django.db.models import Model
 from drf_spectacular.extensions import (
     OpenApiSerializerExtension,
@@ -15,6 +16,7 @@ from rest_framework.fields import empty
 from taggit.serializers import TaggitSerializer, TagListSerializerField
 
 from firefighter.firefighter.utils import get_in
+from firefighter.incidents.enums import IncidentStatus
 from firefighter.incidents.models.environment import Environment
 from firefighter.incidents.models.group import Group
 from firefighter.incidents.models.incident import Incident
@@ -212,7 +214,9 @@ class IncidentSerializer(TaggitSerializer, serializers.ModelSerializer[Incident]
     )
     incident_category = IncidentCategorySerializer(read_only=True)
     incident_category_id = serializers.PrimaryKeyRelatedField(
-        source="incident_category", queryset=IncidentCategory.objects.all(), write_only=True
+        source="incident_category",
+        queryset=IncidentCategory.objects.all(),
+        write_only=True,
     )
 
     status = serializers.SerializerMethodField()
@@ -228,6 +232,18 @@ class IncidentSerializer(TaggitSerializer, serializers.ModelSerializer[Incident]
         slug_field="email",
         queryset=User.objects.all(),
         validators=[EmailValidator()],  # type: ignore[list-item]
+    )
+
+    dedup_key = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_null=True,
+        max_length=160,
+        help_text=(
+            "Optional idempotency key. While an incident with this key is open "
+            "(status <= Mitigated), re-posting it returns that incident (HTTP 200) "
+            "instead of creating a duplicate."
+        ),
     )
 
     tags = TagListSerializerField(read_only=True)
@@ -277,7 +293,28 @@ class IncidentSerializer(TaggitSerializer, serializers.ModelSerializer[Incident]
         return None
 
     def create(self, validated_data: dict[str, Any]) -> Incident:
-        return Incident.objects.declare(**validated_data)
+        dedup_key = validated_data.get("dedup_key")
+        try:
+            return Incident.objects.declare(**validated_data)
+        except IntegrityError:
+            # An open incident (status <= Mitigated) already exists with this
+            # dedup_key (enforced by the partial unique constraint). Treat the
+            # request as idempotent: return the existing incident rather than
+            # raising, and flag it so the view answers HTTP 200 instead of 201.
+            # We catch IntegrityError broadly but only swallow it when a matching
+            # open incident actually exists; any other integrity error re-raises.
+            if dedup_key:
+                existing = (
+                    Incident.objects.filter(
+                        dedup_key=dedup_key, _status__lte=IncidentStatus.MITIGATED
+                    )
+                    .order_by("created_at")
+                    .first()
+                )
+                if existing is not None:
+                    existing._idempotent_hit = True  # type: ignore[attr-defined]  # noqa: SLF001
+                    return existing
+            raise
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         remove_fields = get_in(kwargs, "context.remove_fields", [])
@@ -317,4 +354,5 @@ class IncidentSerializer(TaggitSerializer, serializers.ModelSerializer[Incident]
             "metrics",
             "roles",
             "ignore",
+            "dedup_key",
         ]

--- a/src/firefighter/api/views/incidents.py
+++ b/src/firefighter/api/views/incidents.py
@@ -244,7 +244,11 @@ class CreateIncidentViewSet(
     viewsets.GenericViewSet[Incident],
 ):
     queryset: QuerySet[Incident] = Incident.objects.all().select_related(
-        "priority", "incident_category__group", "incident_category", "environment", "conversation"
+        "priority",
+        "incident_category__group",
+        "incident_category",
+        "environment",
+        "conversation",
     )
     serializer_class = IncidentSerializer
     filterset_class = IncidentFilterSet
@@ -258,6 +262,12 @@ class CreateIncidentViewSet(
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
+        # Idempotent hit: an open incident already existed for this dedup_key.
+        # Return 200 with a plain Response so we do NOT re-trigger Slack channel
+        # creation (ProcessAfterResponse.close() fires create_incident_conversation)
+        # for an incident that already has its conversation.
+        if getattr(serializer.instance, "_idempotent_hit", False):
+            return Response(serializer.data, status=status.HTTP_200_OK, headers=headers)
         return ProcessAfterResponse(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )

--- a/src/firefighter/incidents/migrations/0034_add_incident_dedup_key.py
+++ b/src/firefighter/incidents/migrations/0034_add_incident_dedup_key.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("incidents", "0033_create_jira_webhook_service_user"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="incident",
+            name="dedup_key",
+            field=models.CharField(
+                blank=True,
+                null=True,
+                max_length=160,
+                help_text=(
+                    "Idempotency key for automated sources (e.g. Datadog->IMPACT). "
+                    "While the incident is open (status <= Mitigated), no two incidents "
+                    "may share a dedup_key. Left empty (NULL) for manually-created "
+                    "incidents, which are never de-duplicated."
+                ),
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="incident",
+            # At most one *open* incident (status <= 40 == Mitigated) per dedup_key.
+            # Partial unique index: NULL keys never collide, and once an incident
+            # reaches Post-mortem/Closed it leaves the index, freeing the key for a
+            # future recurrence.
+            constraint=models.UniqueConstraint(
+                fields=("dedup_key",),
+                condition=models.Q(("dedup_key__isnull", False), ("_status__lte", 40)),
+                name="incidents_incident__unique_open_dedup_key",
+            ),
+        ),
+    ]

--- a/src/firefighter/incidents/models/incident.py
+++ b/src/firefighter/incidents/models/incident.py
@@ -248,6 +248,13 @@ class Incident(models.Model):
         help_text="Custom fields for incident (zendesk_ticket_id, seller_contract_id, etc.)",
     )
 
+    dedup_key = models.CharField(
+        max_length=160,
+        null=True,
+        blank=True,
+        help_text="Idempotency key for automated sources (e.g. Datadog->IMPACT). While the incident is open (status <= Mitigated), no two incidents may share a dedup_key. Left empty (NULL) for manually-created incidents, which are never de-duplicated.",
+    )
+
     # XXX-ZOR pick a more meaningful name. maybe 'hidden'
     # XXX-ZOR document intent and impl. status
     ignore = models.BooleanField(
@@ -290,6 +297,15 @@ class Incident(models.Model):
                 name="%(app_label)s_%(class)s_closure_reason_valid",
                 check=models.Q(closure_reason__in=[*ClosureReason.values, ""])
                 | models.Q(closure_reason__isnull=True),
+            ),
+            # Idempotency: at most one *open* incident (status <= Mitigated) per
+            # dedup_key. Partial index, so NULL keys never collide and closed/
+            # post-mortem incidents free the key for a future recurrence.
+            models.UniqueConstraint(
+                fields=["dedup_key"],
+                condition=models.Q(dedup_key__isnull=False)
+                & models.Q(_status__lte=IncidentStatus.MITIGATED),
+                name="%(app_label)s_%(class)s__unique_open_dedup_key",
             ),
         ]
 
@@ -405,7 +421,11 @@ class Incident(models.Model):
                             )
                         )
                 except Exception as e:  # pragma: no cover - defensive guard
-                    jira_key = self.jira_postmortem_for.jira_issue_key if self.jira_postmortem_for else "unknown"
+                    jira_key = (
+                        self.jira_postmortem_for.jira_issue_key
+                        if self.jira_postmortem_for
+                        else "unknown"
+                    )
                     logger.exception(
                         "Failed to verify Jira post-mortem status for incident #%s (JIRA issue: %s)",
                         self.id,
@@ -422,9 +442,13 @@ class Incident(models.Model):
                     support_channel_mention = ""
                     from firefighter.slack.models.conversation import Conversation
 
-                    support_conv = Conversation.objects.get_or_none(tag="dev_firefighter")
+                    support_conv = Conversation.objects.get_or_none(
+                        tag="dev_firefighter"
+                    )
                     if support_conv:
-                        support_channel_mention = f" Please contact <#{support_conv.channel_id}> for help."
+                        support_channel_mention = (
+                            f" Please contact <#{support_conv.channel_id}> for help."
+                        )
 
                     cant_closed_reasons.append(
                         (

--- a/tests/test_api/test_incident_idempotency.py
+++ b/tests/test_api/test_incident_idempotency.py
@@ -1,0 +1,69 @@
+"""Tests for the idempotent create path in ``IncidentSerializer``.
+
+When ``declare()`` hits the partial unique constraint (an open incident already
+exists for the given ``dedup_key``), the serializer returns the existing incident
+and flags it so the view answers HTTP 200 instead of 201.
+
+``declare()`` is patched to raise ``IntegrityError`` directly, isolating the
+serializer's conflict-handling branch from DB/severity setup.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.db import IntegrityError
+
+from firefighter.api.serializers import IncidentSerializer
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory
+
+DEDUP_KEY = "mon:108013180:pim_offer:stg"
+
+
+@pytest.mark.django_db
+def test_create_returns_existing_open_incident_on_conflict() -> None:
+    existing = IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN)
+    serializer = IncidentSerializer()
+
+    with patch(
+        "firefighter.api.serializers.Incident.objects.declare",
+        side_effect=IntegrityError("duplicate key value"),
+    ):
+        result = serializer.create(
+            {"dedup_key": DEDUP_KEY, "title": "t", "description": "d"}
+        )
+
+    assert result.pk == existing.pk
+    assert getattr(result, "_idempotent_hit", False) is True
+
+
+@pytest.mark.django_db
+def test_create_reraises_when_no_matching_open_incident() -> None:
+    serializer = IncidentSerializer()
+
+    with (
+        patch(
+            "firefighter.api.serializers.Incident.objects.declare",
+            side_effect=IntegrityError("some other integrity error"),
+        ),
+        pytest.raises(IntegrityError),
+    ):
+        serializer.create(
+            {"dedup_key": "no-such-open-key", "title": "t", "description": "d"}
+        )
+
+
+@pytest.mark.django_db
+def test_create_reraises_when_no_dedup_key() -> None:
+    serializer = IncidentSerializer()
+
+    with (
+        patch(
+            "firefighter.api.serializers.Incident.objects.declare",
+            side_effect=IntegrityError("unrelated"),
+        ),
+        pytest.raises(IntegrityError),
+    ):
+        serializer.create({"title": "t", "description": "d"})

--- a/tests/test_incidents/test_models/test_incident_dedup_key.py
+++ b/tests/test_incidents/test_models/test_incident_dedup_key.py
@@ -1,0 +1,48 @@
+"""Tests for the `dedup_key` idempotency constraint on Incident.
+
+The partial unique index guarantees at most one *open* incident
+(``_status <= MITIGATED``) per ``dedup_key``. NULL keys never collide, and once
+an incident leaves the open window (Post-mortem / Closed) the key is freed for a
+future recurrence.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import IntegrityError
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory
+from firefighter.incidents.models.incident import Incident
+
+DEDUP_KEY = "mon:108013180:pim_offer:stg"
+
+
+@pytest.mark.django_db
+class TestIncidentDedupKeyConstraint:
+    def test_two_open_incidents_cannot_share_dedup_key(self) -> None:
+        IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN)
+        with pytest.raises(IntegrityError):
+            IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN)
+
+    def test_mitigated_incident_still_blocks_same_dedup_key(self) -> None:
+        # MITIGATED (40) is still inside the "open" window (<= 40).
+        IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.MITIGATED)
+        with pytest.raises(IntegrityError):
+            IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN)
+
+    def test_dedup_key_is_freed_once_past_open_window(self) -> None:
+        first = IncidentFactory.create(dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN)
+        # Move past the open window (Post-mortem = 50 > 40) without triggering
+        # model save side effects.
+        Incident.objects.filter(pk=first.pk).update(_status=IncidentStatus.POST_MORTEM)
+        # A new open incident with the same key is now allowed.
+        second = IncidentFactory.create(
+            dedup_key=DEDUP_KEY, _status=IncidentStatus.OPEN
+        )
+        assert second.pk != first.pk
+
+    def test_null_dedup_key_never_collides(self) -> None:
+        first = IncidentFactory.create(dedup_key=None, _status=IncidentStatus.OPEN)
+        second = IncidentFactory.create(dedup_key=None, _status=IncidentStatus.OPEN)
+        assert first.pk != second.pk


### PR DESCRIPTION
## What

Adds **server-side de-duplication** for incident creation: `POST /api/v2/firefighter/incidents` now accepts an optional `dedup_key`, and at most **one *open* incident** can exist per key. Automated sources can safely retry/re-deliver without opening duplicate incidents.

This is the **IMPACT half of QC-159** (Datadog → IMPACT auto-raise; ADR-0110). It is independently mergeable and fully backward-compatible — manual creation paths (Slack/web) send no `dedup_key` (NULL) and are unaffected.

## Why

The Datadog→IMPACT mechanism re-delivers and the source monitors flap heavily, so without dedup each alert would open a new P3 (and a new Slack channel). Doing dedup at the source of truth (the incident store) is atomic, correct across the incident lifecycle, and reusable by every future adopter — strictly better than a per-receiver dedup store.

## How

- **`Incident.dedup_key`** — optional `CharField` (NULL for manual incidents).
- **Partial unique constraint** — `UNIQUE(dedup_key) WHERE dedup_key IS NOT NULL AND _status <= Mitigated (40)`.
  - Atomic → no duplicate even under concurrent delivery (no TOCTOU).
  - NULL keys never collide.
  - Once an incident reaches **Post-mortem/Closed** it leaves the partial index, so a later recurrence opens a **new** incident (no permanent blocking).
- **API** — serializer accepts write-only `dedup_key`; on conflict it returns the existing open incident with **HTTP 200** (instead of 201) and **does not** re-trigger the Slack channel workflow.

## Tests

- Model: collision while open, Mitigated still blocks, key freed past the open window, NULL never collides.
- Serializer: returns existing incident on conflict / re-raises otherwise.
- ✅ Full Python CI green on the branch (tests on Postgres, mypy, ruff, build).

## Notes for review (Pulse)

- Migration `0034` adds a partial unique index on `incidents_incident` (small table → normal build is fine; switch to `CREATE UNIQUE INDEX CONCURRENTLY` if a zero-lock build is preferred).
- "Open" window is `_status <= 40` (Mitigated) — a recurrence during Post-mortem opens a new incident (intended).
- `except IntegrityError` is broad but only swallowed when a matching open incident exists; otherwise re-raised.