### PR TITLE
fix(dust): send actionable post-mortem instruction to Dust agent

### DIFF
--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -12,6 +12,8 @@ from firefighter.slack.slack_app import DefaultWebClient, slack_client
 if TYPE_CHECKING:
     from slack_sdk.web.client import WebClient
 
+    from firefighter.incidents.models.incident import Incident
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,6 +36,22 @@ def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
     return None
 
 
+def _build_dust_message(bot_user_id: str, incident: Incident) -> str:
+    """Build the English instruction posted to the Dust agent in the channel."""
+    jira_pm = getattr(incident, "jira_postmortem_for", None)
+    ticket_ref = (
+        f"the post-mortem Jira ticket <{jira_pm.issue_url}|{jira_pm.jira_issue_key}>"
+        if jira_pm is not None
+        else "the post-mortem for this incident"
+    )
+    return (
+        f"<@{bot_user_id}> ~IncidentManagementPostMortem "
+        f"Please update {ticket_ref} for this incident. "
+        "Read through this incident channel and fill in the post-mortem: "
+        "summary, timeline, root cause, impact, and action items."
+    )
+
+
 @shared_task(
     name="slack.generate_dust_postmortem",
     autoretry_for=(SlackApiError,),
@@ -47,7 +65,9 @@ def generate_dust_postmortem(
 ) -> None:
     from firefighter.incidents.models.incident import Incident
 
-    incident = Incident.objects.select_related("conversation").get(id=incident_id)
+    incident = Incident.objects.select_related(
+        "conversation", "jira_postmortem_for"
+    ).get(id=incident_id)
     if not hasattr(incident, "conversation"):
         logger.warning("Incident %s has no Slack channel, skipping Dust trigger", incident_id)
         return
@@ -71,6 +91,6 @@ def generate_dust_postmortem(
 
     client.chat_postMessage(
         channel=channel_id,
-        text=f"<@{bot_user_id}> ~IncidentManagementPostMortem",
+        text=_build_dust_message(bot_user_id, incident),
     )
     logger.info("Sent Dust post-mortem generation request for incident %s", incident_id)

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -6,6 +6,7 @@ import pytest
 from slack_sdk.errors import SlackApiError
 
 from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.jira_app.models import JiraPostMortem
 from firefighter.slack.factories import IncidentChannelFactory
 from firefighter.slack.tasks.generate_dust_postmortem import generate_dust_postmortem
 
@@ -53,6 +54,33 @@ def test_invites_bot_and_posts_message(settings) -> None:
     assert call_kwargs["channel"] == channel_id
     assert "UDUSTBOT1" in call_kwargs["text"]
     assert "~IncidentManagementPostMortem" in call_kwargs["text"]
+
+
+@pytest.mark.django_db
+def test_message_includes_jira_postmortem_link(settings) -> None:
+    """When a Jira post-mortem exists, its link is embedded in the instruction."""
+    settings.DUST_SLACK_BOT_NAME = "dust"
+    incident = _make_incident_with_channel()
+    jira_pm = JiraPostMortem.objects.create(
+        incident=incident,
+        jira_issue_key="INCIDENT-27688",
+        jira_issue_id="123456",
+    )
+
+    mock_client = MagicMock()
+    mock_client.conversations_invite.return_value = {"ok": True}
+    mock_client.chat_postMessage.return_value = {"ok": True}
+
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+        return_value="UDUSTBOT1",
+    ):
+        generate_dust_postmortem(incident.id, client=mock_client)
+
+    text = mock_client.chat_postMessage.call_args.kwargs["text"]
+    assert jira_pm.jira_issue_key in text
+    assert jira_pm.issue_url in text
+    assert "fill in the post-mortem" in text
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

When the *Generate post-mortem with Dust* button is clicked, the task invited the Dust bot and posted only `<@Dust> ~IncidentManagementPostMortem`. That bare agent call gives Dust no context, and in practice the workspace surfaces the *"To enable Slack Workflows to call Dust agents"* error — the agent receives no actionable instruction.

## Change

- Post a full English instruction that references the Jira post-mortem ticket link and explicitly asks the agent to fill in the post-mortem (summary, timeline, root cause, impact, action items).
- Keep the `~IncidentManagementPostMortem` agent routing.
- Prefetch `jira_postmortem_for` (`select_related`) to build the ticket link, with a graceful fallback when no Jira post-mortem exists.

### Message now posted
> `<@Dust>` ~IncidentManagementPostMortem Please update the post-mortem Jira ticket `<url|INCIDENT-XXXXX>` for this incident. Read through this incident channel and fill in the post-mortem: summary, timeline, root cause, impact, and action items.

## Tests

- New `test_message_includes_jira_postmortem_link` asserts the Jira key, URL and instruction are embedded.
- Existing task tests still pass (5/5). ruff + mypy clean on changed files.