### PR TITLE
feat(api): create a Jira ticket for API-created incidents (QC-159)

### DIFF
--- a/src/firefighter/api/views/incidents.py
+++ b/src/firefighter/api/views/incidents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Never
 
 from django.db.models import Prefetch, QuerySet
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from rest_framework.serializers import BaseSerializer
 
 
+logger = logging.getLogger(__name__)
+
+
 class ProcessAfterResponse(Response):
     """Custom DRF Response, to trigger the Slack workflow after creating the incident and returning HTTP 201."""
 
@@ -30,6 +34,59 @@ class ProcessAfterResponse(Response):
         create_incident_conversation.send(
             "api",
             incident=incident,
+        )
+        _create_jira_ticket_for_api_incident(incident)
+
+
+def _create_jira_ticket_for_api_incident(incident: Incident) -> None:
+    """Best-effort: create a linked Jira ticket for an API-created incident.
+
+    Incidents opened via the Slack/unified form get a Jira ticket
+    (``UnifiedIncidentForm._create_jira_ticket``); incidents created via the API
+    (e.g. the Datadog->IMPACT auto-raise receiver) previously did not. This mirrors
+    that behaviour for the automated path so QC-159's "generate a Jira incident"
+    holds there too.
+
+    Runs only on genuine 201 creates: this ``Response`` subtype is used only on a
+    real create, not on the idempotent 200 path, so repeats never spawn a ticket.
+    Fields are reconstructed from the incident (there is no form data). Failures are
+    logged and swallowed on purpose - raising an incident must not depend on Jira
+    availability (trade-off: no auto-heal if Jira is down; the incident is still raised).
+    """
+    try:
+        from firefighter.raid.client import client as jira_client
+        from firefighter.raid.forms import prepare_jira_fields
+        from firefighter.raid.models import JiraTicket
+        from firefighter.raid.service import get_jira_user_from_user
+
+        # Insurance against a double ticket; the form path never routes through this view.
+        if JiraTicket.objects.filter(incident=incident).exists():
+            return
+
+        reporter = get_jira_user_from_user(incident.created_by)
+        environments = [incident.environment.value] if incident.environment else []
+        jira_fields = prepare_jira_fields(
+            title=incident.title,
+            description=incident.description,
+            priority=incident.priority.value,
+            reporter=reporter.id,
+            incident_category=incident.incident_category.name,
+            environments=environments,
+            platforms=[],
+            impacts_data={},
+            optional_fields=incident.custom_fields or {},
+        )
+        issue_data = jira_client.create_issue(**jira_fields)
+        JiraTicket.objects.create(**issue_data, incident=incident)
+        logger.info(
+            "Created Jira ticket %s for API-created incident #%s",
+            issue_data.get("key"),
+            incident.id,
+        )
+    except Exception:
+        logger.exception(
+            "Best-effort Jira ticket creation failed for API-created incident #%s",
+            getattr(incident, "id", "unknown"),
         )
 
 

--- a/src/firefighter/api/views/incidents.py
+++ b/src/firefighter/api/views/incidents.py
@@ -39,19 +39,15 @@ class ProcessAfterResponse(Response):
 
 
 def _create_jira_ticket_for_api_incident(incident: Incident) -> None:
-    """Best-effort: create a linked Jira ticket for an API-created incident.
+    """Create a linked Jira ticket for an incident opened through the API.
 
-    Incidents opened via the Slack/unified form get a Jira ticket
-    (``UnifiedIncidentForm._create_jira_ticket``); incidents created via the API
-    (e.g. the Datadog->IMPACT auto-raise receiver) previously did not. This mirrors
-    that behaviour for the automated path so QC-159's "generate a Jira incident"
-    holds there too.
+    Incidents opened through the Slack form already get a Jira ticket; ones created
+    through the API did not, so this brings the two paths in line.
 
-    Runs only on genuine 201 creates: this ``Response`` subtype is used only on a
-    real create, not on the idempotent 200 path, so repeats never spawn a ticket.
-    Fields are reconstructed from the incident (there is no form data). Failures are
-    logged and swallowed on purpose - raising an incident must not depend on Jira
-    availability (trade-off: no auto-heal if Jira is down; the incident is still raised).
+    Only runs on a real create (this response type is not used for the idempotent
+    duplicate case), so repeats do not create extra tickets. Fields are taken from
+    the incident since there is no form data. Best-effort: if Jira is unavailable the
+    failure is logged and ignored, because raising an incident must not depend on Jira.
     """
     try:
         from firefighter.raid.client import client as jira_client
@@ -59,7 +55,7 @@ def _create_jira_ticket_for_api_incident(incident: Incident) -> None:
         from firefighter.raid.models import JiraTicket
         from firefighter.raid.service import get_jira_user_from_user
 
-        # Insurance against a double ticket; the form path never routes through this view.
+        # Safety net against a duplicate ticket; the form path does not reach here.
         if JiraTicket.objects.filter(incident=incident).exists():
             return
 

--- a/src/firefighter/api/views/incidents.py
+++ b/src/firefighter/api/views/incidents.py
@@ -31,11 +31,14 @@ class ProcessAfterResponse(Response):
     def close(self) -> None:
         super().close()
         incident = Incident.objects.get(id=self.data["id"])
+        # Create the Jira ticket before opening the Slack channel, so the declared
+        # announcement can include the ticket link (it is rendered only when the
+        # incident already has a linked ticket).
+        _create_jira_ticket_for_api_incident(incident)
         create_incident_conversation.send(
             "api",
             incident=incident,
         )
-        _create_jira_ticket_for_api_incident(incident)
 
 
 def _create_jira_ticket_for_api_incident(incident: Incident) -> None:

--- a/tests/test_api/test_incident_jira_ticket.py
+++ b/tests/test_api/test_incident_jira_ticket.py
@@ -1,9 +1,8 @@
 """Tests for ``_create_jira_ticket_for_api_incident`` (api/views/incidents.py).
 
-API-created incidents (e.g. the Datadog->IMPACT auto-raise receiver) must get a
-linked Jira ticket like Slack/unified-form incidents do (QC-159). The helper
-reconstructs the Jira fields from the incident, creates the ticket best-effort,
-and never raises (an auto-raised incident must not depend on Jira availability).
+Incidents created through the API must get a linked Jira ticket like the ones
+opened through the Slack form. The helper takes the Jira fields from the incident,
+creates the ticket best-effort, and never raises if Jira is unavailable.
 
 Everything is mocked (no DB): the helper's DB/Jira calls are patched at their
 source modules, and the incident is a stand-in with the attributes the helper reads.

--- a/tests/test_api/test_incident_jira_ticket.py
+++ b/tests/test_api/test_incident_jira_ticket.py
@@ -1,0 +1,98 @@
+"""Tests for ``_create_jira_ticket_for_api_incident`` (api/views/incidents.py).
+
+API-created incidents (e.g. the Datadog->IMPACT auto-raise receiver) must get a
+linked Jira ticket like Slack/unified-form incidents do (QC-159). The helper
+reconstructs the Jira fields from the incident, creates the ticket best-effort,
+and never raises (an auto-raised incident must not depend on Jira availability).
+
+Everything is mocked (no DB): the helper's DB/Jira calls are patched at their
+source modules, and the incident is a stand-in with the attributes the helper reads.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from firefighter.api.views.incidents import _create_jira_ticket_for_api_incident
+
+
+def _incident() -> MagicMock:
+    inc = MagicMock()
+    inc.id = 123
+    inc.title = "[STG] datasets-builder failure"
+    inc.description = "boom"
+    inc.priority.value = 3
+    inc.incident_category.name = "Spinak"
+    inc.environment.value = "STG"
+    inc.custom_fields = {}
+    return inc
+
+
+@patch("firefighter.raid.models.JiraTicket")
+@patch("firefighter.raid.client.client")
+@patch("firefighter.raid.service.get_jira_user_from_user")
+@patch("firefighter.raid.forms.prepare_jira_fields")
+def test_creates_jira_ticket_from_incident(
+    mock_prepare: MagicMock,
+    mock_get_jira_user: MagicMock,
+    mock_client: MagicMock,
+    mock_jira_ticket: MagicMock,
+) -> None:
+    mock_jira_ticket.objects.filter.return_value.exists.return_value = False
+    mock_get_jira_user.return_value = MagicMock(id="jira-user-1")
+    mock_prepare.return_value = {"summary": "t"}
+    mock_client.create_issue.return_value = {"key": "INC-1", "id": "10001"}
+
+    incident = _incident()
+    _create_jira_ticket_for_api_incident(incident)
+
+    # A ticket is created and linked to the incident.
+    mock_client.create_issue.assert_called_once()
+    mock_jira_ticket.objects.create.assert_called_once()
+    _, create_kwargs = mock_jira_ticket.objects.create.call_args
+    assert create_kwargs["incident"] is incident
+    assert create_kwargs["key"] == "INC-1"
+
+    # Fields are reconstructed from the incident (no form data).
+    _, prep_kwargs = mock_prepare.call_args
+    assert prep_kwargs["priority"] == 3
+    assert prep_kwargs["environments"] == ["STG"]
+    assert prep_kwargs["platforms"] == []
+    assert prep_kwargs["impacts_data"] == {}
+    assert prep_kwargs["reporter"] == "jira-user-1"
+    assert prep_kwargs["incident_category"] == "Spinak"
+
+
+@patch("firefighter.raid.models.JiraTicket")
+@patch("firefighter.raid.client.client")
+@patch("firefighter.raid.service.get_jira_user_from_user")
+@patch("firefighter.raid.forms.prepare_jira_fields")
+def test_best_effort_swallows_jira_errors(
+    mock_prepare: MagicMock,
+    mock_get_jira_user: MagicMock,
+    mock_client: MagicMock,
+    mock_jira_ticket: MagicMock,
+) -> None:
+    mock_jira_ticket.objects.filter.return_value.exists.return_value = False
+    mock_get_jira_user.return_value = MagicMock(id="jira-user-1")
+    mock_prepare.return_value = {"summary": "t"}
+    mock_client.create_issue.side_effect = Exception("Jira is down")
+
+    # Must NOT raise (incident is already created; Jira is best-effort).
+    _create_jira_ticket_for_api_incident(_incident())
+
+    mock_jira_ticket.objects.create.assert_not_called()
+
+
+@patch("firefighter.raid.models.JiraTicket")
+@patch("firefighter.raid.client.client")
+def test_skips_when_ticket_already_exists(
+    mock_client: MagicMock,
+    mock_jira_ticket: MagicMock,
+) -> None:
+    mock_jira_ticket.objects.filter.return_value.exists.return_value = True
+
+    _create_jira_ticket_for_api_incident(_incident())
+
+    mock_client.create_issue.assert_not_called()
+    mock_jira_ticket.objects.create.assert_not_called()


### PR DESCRIPTION
## Summary
Incidents created via the **API** (`POST /api/v2/firefighter/incidents`) — e.g. the Datadog→IMPACT auto-raise receiver — did **not** get a linked Jira ticket, while incidents opened via the Slack/unified form do. This makes the automated path also generate a Jira ticket so the two paths behave the same.

## What & where
Best-effort Jira-ticket creation added in `ProcessAfterResponse.close()` (`api/views/incidents.py`).

- Placed in `close()` because it's only used on a **genuine 201 create** — the idempotent **200** path returns a plain `Response`, so repeats never spawn a ticket (no hand-guarding). It also runs **after** the HTTP response, so a slow/failed Jira call can't 500 the create, and it mirrors the existing Slack-channel trigger on this path.
- **Created before the Slack channel signal** so the declared-incident announcement (and the #tech-incidents general announcement) include the `:jira_new:` ticket link — those messages render `incident.jira_ticket` only when it already exists at build time.

Fields are reconstructed from the incident (no form data):
- `reporter = get_jira_user_from_user(incident.created_by)` — already falls back to the default Jira user for bot creators.
- `environments = [incident.environment.value]`, `platforms=[]`, `impacts_data={}`, `optional_fields = incident.custom_fields or {}`.
- Reuses `prepare_jira_fields` / `jira_client.create_issue` / `JiraTicket.objects.create`, like the form.

**Best-effort:** any failure is logged and swallowed — raising an incident must not depend on Jira availability (trade-off: no auto-heal if Jira is down; the incident + channel are still created, the announcement just omits the link). Guard skips if a ticket already exists.

## Tests
`tests/test_api/test_incident_jira_ticket.py` (mocked, no DB): creates a ticket from the incident, swallows Jira errors, skips when a ticket already exists.

## Notes
- Scoped to the API path; does **not** refactor the form flow (the `raid/forms.py` "deduplicate from forms and incident_created signal" TODO is a separate, larger change).
- Full runtime verification (incl. the announcement showing the link) is post-deploy on INT firefighter. Draft until reviewed.