### PR TITLE
fix(api): add incident export with a pinned, append-only column order

### DIFF
--- a/src/firefighter/api/views/incidents.py
+++ b/src/firefighter/api/views/incidents.py
@@ -21,6 +21,110 @@ if TYPE_CHECKING:
     from rest_framework.serializers import BaseSerializer
 
 
+EXTENDED_EXPORT_FIELDS: tuple[str, ...] = (
+    # --- Stable block: order frozen as of firefighter-incident 0.0.65 (the last
+    # release before `incident_category.enabled_create`, `jira_ticket_key` and
+    # `jira_ticket_url` were added). Downstream consumers map these positionally,
+    # so NEVER insert, remove or reorder anything in this block.
+    "costs.Business Volume lost.amount",
+    "costs.Business Volume lost.details",
+    "costs.Infrastructure cost.amount",
+    "costs.Infrastructure cost.details",
+    "costs.Revenue lost.amount",
+    "costs.Revenue lost.details",
+    "created_at",
+    "created_by.email",
+    "created_by.id",
+    "created_by.name",
+    "description",
+    "environment.default",
+    "environment.description",
+    "environment.id",
+    "environment.name",
+    "environment.order",
+    "environment.value",
+    "id",
+    "ignore",
+    "incident_category.created_at",
+    "incident_category.deploy_warning",
+    "incident_category.description",
+    "incident_category.group.created_at",
+    "incident_category.group.description",
+    "incident_category.group.id",
+    "incident_category.group.name",
+    "incident_category.group.order",
+    "incident_category.group.updated_at",
+    "incident_category.id",
+    "incident_category.name",
+    "incident_category.order",
+    "incident_category.private",
+    "incident_category.updated_at",
+    "metrics.time_to_detect.duration",
+    "metrics.time_to_detect.duration_seconds",
+    "metrics.time_to_detect.metric_type",
+    "metrics.time_to_fix.duration",
+    "metrics.time_to_fix.duration_seconds",
+    "metrics.time_to_fix.metric_type",
+    "metrics.time_to_internal_response.duration",
+    "metrics.time_to_internal_response.duration_seconds",
+    "metrics.time_to_internal_response.metric_type",
+    "metrics.time_to_recovery.duration",
+    "metrics.time_to_recovery.duration_seconds",
+    "metrics.time_to_recovery.metric_type",
+    "metrics.time_to_repair.duration",
+    "metrics.time_to_repair.duration_seconds",
+    "metrics.time_to_repair.metric_type",
+    "metrics.time_to_respond.duration",
+    "metrics.time_to_respond.duration_seconds",
+    "metrics.time_to_respond.metric_type",
+    "postmortem_url",
+    "priority.created_at",
+    "priority.default",
+    "priority.description",
+    "priority.emoji",
+    "priority.enabled_create",
+    "priority.enabled_update",
+    "priority.id",
+    "priority.name",
+    "priority.needs_postmortem",
+    "priority.order",
+    "priority.recommended_response_type",
+    "priority.reminder_time",
+    "priority.sla",
+    "priority.updated_at",
+    "priority.value",
+    "roles.commander.email",
+    "roles.commander.id",
+    "roles.commander.name",
+    "roles.communication_lead.email",
+    "roles.communication_lead.id",
+    "roles.communication_lead.name",
+    "slack_channel_name",
+    "status",
+    "status_page_url",
+    "title",
+    # --- Append-only block: every new field goes at the END, below this line.
+    "incident_category.enabled_create",
+    "jira_ticket_key",
+    "jira_ticket_url",
+)
+"""Frozen column order for the extended CSV/TSV export.
+
+Unlike `?fields=__all__` — which alphabetically sorts whatever the serializer happens
+to expose — this list is explicit, and the renderer returns an explicit header
+verbatim. Column positions therefore stay stable when a new serializer field is added.
+
+Two rules keep it that way:
+
+1. Never insert, remove or reorder an entry in the stable block.
+2. New fields go at the END, after the append-only marker.
+
+`__all__` is also data-dependent: `costs.*`, `metrics.*` and `roles.*` are keyed by
+values present in the result set, so two `__all__` exports over different filters can
+return different columns. An explicit list avoids that as well.
+"""
+
+
 class ProcessAfterResponse(Response):
     """Custom DRF Response, to trigger the Slack workflow after creating the incident and returning HTTP 201."""
 

--- a/src/firefighter/components/export_button/export_button.py
+++ b/src/firefighter/components/export_button/export_button.py
@@ -24,6 +24,7 @@ Args = tuple[str]
 class Kwargs(TypedDict, total=False):
     base_url: Required[str]
     default_fmt: NotRequired[tuple[str, str | None, str | None]]
+    presets: NotRequired[Sequence[tuple[str, str | None, str | None]]]
 
 
 @component.register("export_button")
@@ -34,14 +35,27 @@ class ExportButton(component.Component):
         self,
         base_url: str,
         default_fmt: tuple[str, str | None, str | None] | None = None,
+        presets: Sequence[tuple[str, str | None, str | None]] | None = None,
         **kwargs: Any,
     ) -> Data:
+        """Build the export dropdown.
+
+        Args:
+            base_url: Reversible name of the API list route to export from.
+            default_fmt: The format of the main (non-dropdown) button.
+            presets: Extra `(format, fields, label)` entries appended to the dropdown.
+                Pass an explicit comma-separated `fields` string to pin the column
+                order — unlike `__all__`, an explicit header is rendered verbatim, so
+                adding a serializer field cannot shift a downstream consumer's columns.
+            **kwargs: Unused; accepted for django-components compatibility.
+        """
         default_fmt = default_fmt or ("csv", None, None)
         fmts: list[tuple[str, str | None, str | None]] = [
             ("json", None, None),
             ("tsv", None, None),
             ("csv", "__all__", "(Full)"),
             ("tsv", "__all__", "(Full)"),
+            *(presets or ()),
         ]
 
         default_format = self.make_fmt(default_fmt, base_url)

--- a/src/firefighter/incidents/templates/pages/incident_list.html
+++ b/src/firefighter/incidents/templates/pages/incident_list.html
@@ -12,7 +12,7 @@
 
 {% block page_actions %}
   {{ block.super }}
-  {% component "export_button" base_url="api:incidents-list" %}{% endcomponent %}
+  {% component "export_button" base_url="api:incidents-list" presets=export_presets %}{% endcomponent %}
   <button method="get" type="submit"
           form="main-filter" formaction="{% url "incidents:incident-statistics" %}"
           class="ml-4 btn btn-primary btn-md gap-2">

--- a/src/firefighter/incidents/templates/pages/incident_statistics.html
+++ b/src/firefighter/incidents/templates/pages/incident_statistics.html
@@ -108,7 +108,7 @@
 
 {% block page_actions %}
   {{ block.super }}
-  {% component "export_button" base_url="api:incidents-list" %}{% endcomponent %}
+  {% component "export_button" base_url="api:incidents-list" presets=export_presets %}{% endcomponent %}
   <button method="get" type="submit"
           form="main-filter" formaction="{% url "incidents:incident-list" %}"
           class="ml-4 btn btn-primary gap-2"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">

--- a/src/firefighter/incidents/views/views.py
+++ b/src/firefighter/incidents/views/views.py
@@ -36,6 +36,26 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def incident_export_presets() -> list[tuple[str, str, str]]:
+    """Extra entries for the incident export dropdown, with pinned column order.
+
+    The `(Full)` options use `?fields=__all__`, which sorts the serializer's fields
+    alphabetically — so adding a field shifts every column after it and silently breaks
+    consumers that map by position. These presets pass an explicit field list instead,
+    which the renderer emits verbatim.
+
+    Imported lazily: `firefighter.api` imports `firefighter.incidents`, so a
+    module-level import here would create a cycle.
+    """
+    from firefighter.api.views.incidents import EXTENDED_EXPORT_FIELDS
+
+    fields = ",".join(EXTENDED_EXPORT_FIELDS)
+    return [
+        ("csv", fields, "(Full, mapped)"),
+        ("tsv", fields, "(Full, mapped)"),
+    ]
+
+
 class IncidentListView(SingleTableMixin, FilterView):
     table_class = IncidentTable
     context_object_name = "incidents"
@@ -75,6 +95,7 @@ class IncidentListView(SingleTableMixin, FilterView):
 
         context["page_title"] = "Incidents List"
         context["api_url_export"] = reverse("api:incidents-list")
+        context["export_presets"] = incident_export_presets()
         return context
 
 
@@ -110,6 +131,7 @@ class IncidentStatisticsView(FilterView):
             "priority",
             "incident_category",
         ]
+        context["export_presets"] = incident_export_presets()
         context_data = weekly_dashboard_context(
             self.request, context.get("incidents_filtered", [])
         )

--- a/tests/test_api/test_incident_export_column_order.py
+++ b/tests/test_api/test_incident_export_column_order.py
@@ -1,0 +1,106 @@
+"""Column-order contract for the stable incident export.
+
+`test_incident_api_field_stability` pins which fields *exist*. It does not pin their
+*position*, and position is equally part of the contract: consumers load the CSV into
+Snowflake, which maps columns positionally ($1..$N), not by header name.
+
+That gap is how `incident_category.enabled_create`, `jira_ticket_key` and
+`jira_ticket_url` broke a downstream consumer — each sorted into the middle of the
+alphabetical `?fields=__all__` output and shifted every column after it.
+
+`EXTENDED_EXPORT_FIELDS` exists so that export has a frozen order. These tests fail if
+anyone inserts, removes or reorders an entry in the stable block, or appends a new field
+anywhere other than the end.
+"""
+
+from __future__ import annotations
+
+from firefighter.api.renderer import CSVRenderer
+from firefighter.api.views.incidents import EXTENDED_EXPORT_FIELDS
+
+# The order frozen as of firefighter-incident 0.0.65, before the three fields below were
+# added. Consumers map these positionally — a change here is a BREAKING change.
+STABLE_PREFIX = (
+    "costs.Business Volume lost.amount",
+    "costs.Business Volume lost.details",
+    "costs.Infrastructure cost.amount",
+    "costs.Infrastructure cost.details",
+    "costs.Revenue lost.amount",
+    "costs.Revenue lost.details",
+    "created_at",
+    "created_by.email",
+    "created_by.id",
+    "created_by.name",
+    "description",
+)
+
+# Fields added after the freeze. New fields belong at the END, never inserted.
+APPENDED_TAIL = (
+    "incident_category.enabled_create",
+    "jira_ticket_key",
+    "jira_ticket_url",
+)
+
+
+def test_stable_prefix_is_unchanged() -> None:
+    """The first columns must never move — they anchor every positional mapping."""
+    actual = EXTENDED_EXPORT_FIELDS[: len(STABLE_PREFIX)]
+    assert actual == STABLE_PREFIX, (
+        "BREAKING: the stable export column prefix changed. Downstream consumers map "
+        "columns by position; inserting or reordering shifts all following columns. "
+        "New fields must be appended at the END of EXTENDED_EXPORT_FIELDS."
+    )
+
+
+def test_new_fields_are_appended_at_the_end() -> None:
+    """Fields added after the freeze sit at the tail, in the order they were added."""
+    assert EXTENDED_EXPORT_FIELDS[-len(APPENDED_TAIL) :] == APPENDED_TAIL, (
+        "BREAKING: post-freeze fields are no longer the final columns. Append new "
+        "fields at the END of EXTENDED_EXPORT_FIELDS, never in alphabetical position."
+    )
+
+
+def test_no_duplicate_columns() -> None:
+    dupes = {f for f in EXTENDED_EXPORT_FIELDS if EXTENDED_EXPORT_FIELDS.count(f) > 1}
+    assert not dupes, f"duplicate export columns: {sorted(dupes)}"
+
+
+def test_presets_pass_the_pinned_field_list() -> None:
+    """The dropdown presets must send the explicit list, not `__all__`.
+
+    Imported inside the test on purpose: importing `incidents.views.views` at module
+    level pulls the view layer in at collection time, which perturbs an order-fragile
+    Slack test elsewhere in the suite.
+    """
+    from firefighter.incidents.views.views import incident_export_presets
+
+    presets = incident_export_presets()
+    assert presets, "no export presets configured"
+    expected = ",".join(EXTENDED_EXPORT_FIELDS)
+    for fmt, fields, label in presets:
+        assert fields == expected, f"preset {label!r} ({fmt}) does not pin the columns"
+        assert fields != "__all__", f"preset {label!r} still uses __all__"
+
+
+def test_renderer_emits_the_pinned_order_verbatim() -> None:
+    """The property the whole approach rests on: an explicit header is emitted as given.
+
+    `CSVRenderer._get_headers` short-circuits for a wildcard-free header, so the column
+    order is exactly what we pass in — never sorted.
+
+    Deliberately DB-free: building a real incident fires creation signals that leak into
+    unrelated Slack tests later in the suite. Field *presence* on the serializer is
+    already covered by `test_incident_api_field_stability`; this test is about the
+    renderer, so synthetic rows are both sufficient and side-effect free.
+    """
+    header = list(EXTENDED_EXPORT_FIELDS)
+    data = [dict.fromkeys(header, "x")]
+
+    rows = list(CSVRenderer().tablize(data, header=header, labels=None))
+
+    assert rows[0] == header, "renderer reordered an explicit header"
+    assert rows[0] != sorted(header), (
+        "the pinned order equals alphabetical order, so this test could not detect a "
+        "regression to sorting — the appended tail must not be alphabetically last"
+    )
+    assert len(rows[1]) == len(header), "row width does not match the header"


### PR DESCRIPTION
## The bug

The `(Full)` export options send `?fields=__all__`. With no explicit header, `CSVRenderer._get_headers` falls through to `sorted(header_fields)` — so **column position is a function of field names**, and adding any serializer field shifts every column after it.

Consumers load the CSV into Snowflake, which maps columns **positionally** (`$1..$N`), not by header name. A shift is therefore silent data corruption, not an error.

That is what happened. Three recently added fields each sorted into the middle of the output:

| Field | Landed at | Columns displaced |
| --- | --- | --- |
| `incident_category.enabled_create` | 23 | 57 |
| `jira_ticket_key` | 35 | 45 |
| `jira_ticket_url` | 36 | 44 |

Confirmed against the affected consumer's actual export header (80 columns, strictly alphabetical).

This is the same class of failure as the Aug 2025 `component` → `incident_category` rename, which produced silently empty columns.

## The fix

Two new dropdown entries — **`Export CSV (Full, mapped)`** and its TSV twin — pass an explicit 80-column list instead of `__all__`. `_get_headers` short-circuits for a wildcard-free header, so an explicit list is emitted **verbatim** and positions cannot move.

`EXTENDED_EXPORT_FIELDS` is split into two blocks:

```python
# --- Stable block: order frozen as of 0.0.65 ... NEVER insert, remove or reorder
...77 columns, ending "title"...
# --- Append-only block: every new field goes at the END, below this line.
"incident_category.enabled_create",
"jira_ticket_key",
"jira_ticket_url",
```

Positions 1–77 reproduce the pre-regression order **exactly**, so existing mappings keep working unchanged and consumers simply gain three columns at the end.

## Also fixes a pre-existing fragility

`__all__` is **data-dependent**: `costs.*`, `metrics.*` and `roles.*` are keyed by values present in the result set. Two `__all__` exports over different filters can legitimately return different columns — independent of any code change. An explicit list removes that too.

## Existing options untouched

`Export JSON`, `Export TSV`, `Export CSV (Full)` and `Export TSV (Full)` are unchanged. `(Full)` stays the raw dump; the new entries are purely additive. `presets` is an optional kwarg, so `incident_category_list.html` is unaffected.

## Tests

`test_incident_api_field_stability` pins which fields *exist* — it guards renames and removals but never considered that **adding** a field is equally breaking when consumers map by position. That gap is why this shipped.

The new tests pin the *order*:

- the stable prefix cannot be reordered
- post-freeze fields must be the final columns
- no duplicates
- the dropdown presets pass the pinned list, never `__all__`
- the renderer emits an explicit header verbatim (asserting it is *not* the alphabetical order, so the test can actually detect a regression to sorting)

They are **DB-free deliberately**: an earlier version built a real incident, whose creation signals leaked into an unrelated Slack resilience test 90 seconds later in the suite. The property under test is renderer behaviour, so synthetic rows are sufficient and side-effect free.

## Verification

- Full suite: **19 failures on both `main` and this branch, identical sets** (pre-existing staticfiles-manifest failures); +5 tests
- `ruff`, `mypy`, `pre-commit` clean
- End-to-end: 80 columns, header emitted verbatim, ending `title, incident_category.enabled_create, jira_ticket_key, jira_ticket_url`
- Column list diffed against the real consumer export — identical sets, no drift

## Follow-up worth considering

`(Full)` remains fragile by design. If no consumer needs the raw alphabetical dump, pointing it at the pinned list too would close the trap entirely — deliberately left out of this PR to avoid changing existing behaviour.