### PR TITLE
feat(slack): add timeline review checkpoint before Post-mortem transition

### DIFF
--- a/docs/architecture/jira-integration.md
+++ b/docs/architecture/jira-integration.md
@@ -336,23 +336,23 @@ The Jira post-mortem feature creates dedicated post-mortem issues in Jira when a
 
 **Content**:
 
-- Incident creation event
-- All status changes with timestamps
+- A "Declared" key event marking incident creation (from `Incident.objects.declare()`)
+- All status changes with timestamps, except the OPEN row created at declaration time (its timestamp coincides with "Declared", so it would only duplicate that row) - a later, genuine reopen back to OPEN still shows as its own "Status changed to: Open" row
 - All key events (detected, started, recovered, etc.) with optional messages
 - Sorted chronologically ascending by `event_ts`
 
-**Format** (Jira Wiki Markup):
+**Format** (Jira Wiki Markup). Rows are built from a single chronologically-sorted list (`build_timeline_rows()`) so "Declared" and backfilled milestones (e.g. Started/Detected before the incident was declared) sort correctly against each other; times are rendered in the active timezone (`TIME_ZONE` setting) with its real abbreviation, not a hardcoded "UTC":
 
 ```text
 h2. Timeline
 
 || Time || Event ||
-| 2025-11-19 10:00 UTC | Incident created (P1) |
-| 2025-11-19 10:05 UTC | Status changed to: Investigating |
-| 2025-11-19 10:10 UTC | Key event: Detected - Issue first detected |
-| 2025-11-19 10:15 UTC | Status changed to: Mitigating |
-| 2025-11-19 10:30 UTC | Key event: Recovered - System back to normal |
-| 2025-11-19 10:35 UTC | Status changed to: Mitigated |
+| 2025-11-19 10:00 CET | Key event: Declared |
+| 2025-11-19 10:05 CET | Status changed to: Investigating |
+| 2025-11-19 10:10 CET | Key event: Detected - Issue first detected |
+| 2025-11-19 10:15 CET | Status changed to: Mitigating |
+| 2025-11-19 10:30 CET | Key event: Recovered - System back to normal |
+| 2025-11-19 10:35 CET | Status changed to: Mitigated |
 ```
 
 **Key Events Sync**:

--- a/src/firefighter/incidents/forms/timeline_correction.py
+++ b/src/firefighter/incidents/forms/timeline_correction.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from django import forms
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.models.incident_update import IncidentUpdate
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from firefighter.incidents.models.incident import Incident
+    from firefighter.incidents.models.user import User
+
+# (event_type, display label) - mirrors review_timeline._MILESTONE_EVENT_TYPES.
+_MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
+    ("started", "Started"),
+    ("detected", "Detected"),
+)
+
+
+class TimelineCorrectionForm(forms.Form):
+    """Edit in place the timeline shown in the Post-mortem review checkpoint.
+
+    Two kinds of fields, both keyed to survive round-tripping through Slack's
+    view submission parsing (which strips block/action ids at the first
+    "___" - see `slack_view_submission_to_dict`):
+
+    - `milestone_<event_type>`: same update_or_create/delete semantics as
+      `IncidentUpdateKeyEventsForm._save_key_event` - these rows aren't
+      unique per status, so "which one to touch" is never ambiguous.
+    - `status_<incident_update_id>`: edits that exact `IncidentUpdate` row's
+      `event_ts` in place - required, since a status transition that
+      happened must keep some time. `IncidentStatus.OPEN` has no field, even
+      for a genuine reopen back to OPEN: the declaration's OPEN is always
+      anchored to `incident.created_at` rather than a recorded row, and a
+      later reopen-to-OPEN is deliberately left non-editable here too, to
+      keep the rule simple ("OPEN is never a correction target"). A status
+      revisited after a reopen
+      (MITIGATED -> INVESTIGATING/MITIGATING) gets one field per occurrence,
+      matching `get_status_timeline`'s full history and the Jira post-mortem
+      timeline - labels are numbered ("Mitigating (1)", "Mitigating (2)")
+      only when a status actually recurs.
+    """
+
+    incident: Incident
+    user: User
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.incident = kwargs.pop("incident")
+        self.user = kwargs.pop("user", None)
+        super().__init__(*args, **kwargs)
+        self.generate_fields_dynamically()
+
+    def generate_fields_dynamically(self) -> None:
+        milestone_updates = dict(
+            self.incident.incidentupdate_set.filter(
+                event_type__in=[
+                    event_type for event_type, _ in _MILESTONE_EVENT_TYPES
+                ]
+            ).values_list("event_type", "event_ts")
+        )
+        for event_type, label in _MILESTONE_EVENT_TYPES:
+            field_name = f"milestone_{event_type}"
+            self.fields[field_name] = forms.DateTimeField(
+                required=False,
+                # Slack itself appends "(optional)" next to the label for any
+                # non-required field (see form_utils.py's optional=not
+                # f.required) - adding it here too would show it twice.
+                label=label,
+                widget=forms.DateTimeInput(
+                    attrs={"placeholder": event_type, "type": "datetime-local"}
+                ),
+            )
+            if field_name not in self.initial:
+                self.initial[field_name] = milestone_updates.get(event_type) or ""
+
+        for status, occurrence, total, update in self._status_updates_with_occurrence():
+            field_name = f"status_{update.id}"
+            label = status.label if total == 1 else f"{status.label} ({occurrence})"
+            self.fields[field_name] = forms.DateTimeField(
+                required=True,
+                label=label,
+                widget=forms.DateTimeInput(attrs={"type": "datetime-local"}),
+            )
+            if field_name not in self.initial:
+                self.initial[field_name] = update.event_ts
+
+    def _status_updates_with_occurrence(
+        self,
+    ) -> list[tuple[IncidentStatus, int, int, IncidentUpdate]]:
+        """Every non-OPEN status-change row, in chronological order.
+
+        Yields `(status, occurrence_index, occurrence_total, update)` so a
+        status reached more than once (reopen cycles) can be numbered
+        ("Mitigating (1)", "Mitigating (2)") while a status reached only
+        once keeps a bare label. Mirrors `review_timeline.get_status_timeline`
+        - full history, no dedup - minus the OPEN special-case (OPEN, including
+        a later reopen back to OPEN, is never an editable row here).
+        """
+        updates = list(
+            self.incident.incidentupdate_set.filter(_status__isnull=False)
+            .exclude(_status=IncidentStatus.OPEN)
+            .order_by("event_ts")
+        )
+        totals: dict[IncidentStatus, int] = {}
+        for update in updates:
+            if update.status is not None:
+                totals[update.status] = totals.get(update.status, 0) + 1
+
+        seen: dict[IncidentStatus, int] = {}
+        result: list[tuple[IncidentStatus, int, int, IncidentUpdate]] = []
+        for update in updates:
+            status = update.status
+            if status is None:
+                continue
+            seen[status] = seen.get(status, 0) + 1
+            result.append((status, seen[status], totals[status], update))
+        return result
+
+    def clean(self) -> dict[str, Any] | None:
+        if self.user is None:
+            raise forms.ValidationError("User is required")
+        return super().clean()
+
+    def save(self) -> None:
+        """Save each changed field in place."""
+        for field_name in self.changed_data:
+            value = self.cleaned_data[field_name]
+            if field_name.startswith("milestone_"):
+                self._save_milestone(field_name.removeprefix("milestone_"), value)
+            elif field_name.startswith("status_"):
+                self._save_status(field_name.removeprefix("status_"), value)
+
+    def _save_milestone(self, event_type: str, value: datetime | None) -> None:
+        if value is None:
+            IncidentUpdate.objects.filter(
+                incident_id=self.incident.id, event_type=event_type
+            ).delete()
+            return
+        IncidentUpdate.objects.update_or_create(
+            incident_id=self.incident.id,
+            event_type=event_type,
+            defaults={"event_ts": value, "created_by": self.user},
+        )
+
+    @staticmethod
+    def _save_status(update_id: str, value: datetime) -> None:
+        IncidentUpdate.objects.filter(id=update_id).update(event_ts=value)

--- a/src/firefighter/incidents/forms/timeline_correction.py
+++ b/src/firefighter/incidents/forms/timeline_correction.py
@@ -23,6 +23,18 @@ _MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
 )
 
 
+# Which occurrence of a status is the definitive one when a reopen makes it
+# repeat: investigation *started* at its first occurrence, while the mitigation
+# that actually held is the last one. Shared with the Slack review message so
+# both surfaces show and edit the same timestamp.
+DEFINITIVE_OCCURRENCE: dict[IncidentStatus, str] = {
+    IncidentStatus.INVESTIGATING: "first",
+    IncidentStatus.MITIGATING: "last",
+    IncidentStatus.MITIGATED: "last",
+}
+_DEFAULT_OCCURRENCE = "last"
+
+
 class TimelineCorrectionForm(forms.Form):
     """Edit in place the timeline shown in the Post-mortem review checkpoint.
 
@@ -62,7 +74,12 @@ class TimelineCorrectionForm(forms.Form):
                 event_type__in=[
                     event_type for event_type, _ in _MILESTONE_EVENT_TYPES
                 ]
-            ).values_list("event_type", "event_ts")
+            )
+            # Explicit ordering: without it Meta.ordering ("-event_ts") applies and
+            # dict() would keep the OLDEST row per type, while the review message
+            # keeps the newest - the two surfaces would disagree on the same field.
+            .order_by("event_ts")
+            .values_list("event_type", "event_ts")
         )
         for event_type, label in _MILESTONE_EVENT_TYPES:
             field_name = f"milestone_{event_type}"
@@ -79,9 +96,14 @@ class TimelineCorrectionForm(forms.Form):
             if field_name not in self.initial:
                 self.initial[field_name] = milestone_updates.get(event_type) or ""
 
-        for status, occurrence, total, update in self._status_updates_with_occurrence():
+        for status, total, update in self._editable_status_updates():
             field_name = f"status_{update.id}"
-            label = status.label if total == 1 else f"{status.label} ({occurrence})"
+            which = DEFINITIVE_OCCURRENCE.get(status, _DEFAULT_OCCURRENCE)
+            label = (
+                status.label
+                if total == 1
+                else f"{status.label} ({which} of {total})"
+            )
             self.fields[field_name] = forms.DateTimeField(
                 required=True,
                 label=label,
@@ -90,17 +112,20 @@ class TimelineCorrectionForm(forms.Form):
             if field_name not in self.initial:
                 self.initial[field_name] = update.event_ts
 
-    def _status_updates_with_occurrence(
+    def _editable_status_updates(
         self,
-    ) -> list[tuple[IncidentStatus, int, int, IncidentUpdate]]:
-        """Every non-OPEN status-change row, in chronological order.
+    ) -> list[tuple[IncidentStatus, int, IncidentUpdate]]:
+        """One editable row per non-OPEN status, in chronological order.
 
-        Yields `(status, occurrence_index, occurrence_total, update)` so a
-        status reached more than once (reopen cycles) can be numbered
-        ("Mitigating (1)", "Mitigating (2)") while a status reached only
-        once keeps a bare label. Mirrors `review_timeline.get_status_timeline`
-        - full history, no dedup - minus the OPEN special-case (OPEN, including
-        a later reopen back to OPEN, is never an editable row here).
+        A status reached several times (reopen cycles) yields a single field
+        bound to its *last* occurrence: that is the time the incident actually
+        settled on, the one the post-mortem timeline shows, and the only one
+        worth correcting. Earlier occurrences stay as recorded - they are the
+        history of the failed attempts, not a mistake to fix.
+
+        Returns `(status, occurrence_count, update)`; the count is surfaced in
+        the label ("Mitigated (last of 4)") rather than as one numbered field
+        per cycle. OPEN is never editable here, including a later reopen to OPEN.
         """
         updates = list(
             self.incident.incidentupdate_set.filter(_status__isnull=False)
@@ -108,19 +133,22 @@ class TimelineCorrectionForm(forms.Form):
             .order_by("event_ts")
         )
         totals: dict[IncidentStatus, int] = {}
-        for update in updates:
-            if update.status is not None:
-                totals[update.status] = totals.get(update.status, 0) + 1
-
-        seen: dict[IncidentStatus, int] = {}
-        result: list[tuple[IncidentStatus, int, int, IncidentUpdate]] = []
+        chosen: dict[IncidentStatus, IncidentUpdate] = {}
         for update in updates:
             status = update.status
             if status is None:
                 continue
-            seen[status] = seen.get(status, 0) + 1
-            result.append((status, seen[status], totals[status], update))
-        return result
+            totals[status] = totals.get(status, 0) + 1
+            which = DEFINITIVE_OCCURRENCE.get(status, _DEFAULT_OCCURRENCE)
+            if which == "last" or status not in chosen:
+                chosen[status] = update
+
+        return [
+            (status, totals[status], update)
+            for status, update in sorted(
+                chosen.items(), key=lambda item: item[1].event_ts
+            )
+        ]
 
     def clean(self) -> dict[str, Any] | None:
         if self.user is None:

--- a/src/firefighter/jira_app/service_postmortem.py
+++ b/src/firefighter/jira_app/service_postmortem.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from django.conf import settings
 from django.template.loader import render_to_string
 
+from firefighter.incidents.enums import IncidentStatus
 from firefighter.jira_app.client import (
     JiraClient,
     JiraUserDatabaseError,
@@ -21,6 +22,47 @@ if TYPE_CHECKING:
     from firefighter.incidents.models.user import User
 
 logger = logging.getLogger(__name__)
+
+
+class TimelineRow(NamedTuple):
+    event_ts: datetime
+    label: str
+
+
+def build_timeline_rows(incident: Incident) -> list[TimelineRow]:
+    """Merge all status changes and key events into one chronologically sorted list.
+
+    The `OPEN` row created at declaration time is skipped - it shares its
+    `event_ts` with `Incident.objects.declare()`'s "declared" key event,
+    which already marks when the incident was created (priority is shown in
+    the incident summary section, not repeated here), so showing both would
+    just duplicate the same instant. An incident can legitimately go back to
+    `OPEN` later (a real reopen); that row has a different `event_ts` than
+    the declaration and is kept, rendering as its own "Status changed to:
+    Open" line. Sorting everything together (rather than pinning any one
+    event first) keeps the rendered timeline chronologically correct even
+    when e.g. Started/Detected are backfilled to before the incident was
+    declared in FireFighter.
+    """
+    rows: list[TimelineRow] = []
+    for update in incident.incidentupdate_set.all():
+        if update.status:
+            is_declaration_open = (
+                update.status == IncidentStatus.OPEN
+                and update.event_ts == incident.created_at
+            )
+            if not is_declaration_open:
+                rows.append(
+                    TimelineRow(
+                        update.event_ts, f"Status changed to: {update.status.label}"
+                    )
+                )
+        if update.event_type:
+            label = f"Key event: {update.event_type.title()}"
+            if update.message:
+                label += f" - {update.message}"
+            rows.append(TimelineRow(update.event_ts, label))
+    return sorted(rows, key=lambda row: row.event_ts)
 
 
 class JiraPostMortemService:
@@ -174,6 +216,7 @@ class JiraPostMortemService:
             "priority": incident.priority,
             "created_at": incident.created_at,
             "components": [],  # No component relationship available
+            "timeline_rows": build_timeline_rows(incident),
         }
 
         incident_summary = render_to_string(

--- a/src/firefighter/jira_app/signals/__init__.py
+++ b/src/firefighter/jira_app/signals/__init__.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from firefighter.jira_app.signals.incident_key_events_updated import (
     sync_key_events_to_jira_postmortem,
+    sync_timeline_to_jira_postmortem,
 )
 from firefighter.jira_app.signals.postmortem_created import (
     postmortem_created_handler,
 )
 
-__all__ = ["postmortem_created_handler", "sync_key_events_to_jira_postmortem"]
+__all__ = [
+    "postmortem_created_handler",
+    "sync_key_events_to_jira_postmortem",
+    "sync_timeline_to_jira_postmortem",
+]

--- a/src/firefighter/jira_app/signals/incident_key_events_updated.py
+++ b/src/firefighter/jira_app/signals/incident_key_events_updated.py
@@ -12,7 +12,10 @@ from django.template.loader import render_to_string
 from firefighter.incidents.models.incident import Incident as IncidentModel
 from firefighter.incidents.signals import incident_key_events_updated
 from firefighter.jira_app.client import JiraClient
-from firefighter.jira_app.service_postmortem import JiraPostMortemService
+from firefighter.jira_app.service_postmortem import (
+    JiraPostMortemService,
+    build_timeline_rows,
+)
 
 if TYPE_CHECKING:
     from firefighter.incidents.models.incident import Incident
@@ -20,19 +23,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@receiver(signal=incident_key_events_updated)
-def sync_key_events_to_jira_postmortem(
-    sender: Any, incident: Incident, **kwargs: dict[str, Any]
-) -> None:
-    """Update Jira post-mortem timeline when key events are updated.
+def sync_timeline_to_jira_postmortem(incident: Incident) -> None:
+    """Render the incident's timeline and push it to its Jira post-mortem's Timeline field.
 
-    This handler is triggered when incident key events are updated via the web UI
-    or Slack, and syncs the timeline to the associated Jira post-mortem ticket.
+    No-op if Jira post-mortem is disabled, or the incident has no Jira post-mortem.
+    Shared by the key-events-updated signal receiver below and by other callers
+    that want to push a freshly-confirmed timeline on demand (e.g. the Slack
+    timeline review checkpoint, once a human accepts it).
 
     Args:
-        sender: The sender of the signal
-        incident: The incident whose key events were updated
-        **kwargs: Additional keyword arguments
+        incident: The incident whose timeline should be synced to Jira
     """
     # Check if Jira post-mortem is enabled
     if not getattr(settings, "ENABLE_JIRA_POSTMORTEM", False):
@@ -46,7 +46,7 @@ def sync_key_events_to_jira_postmortem(
 
     jira_postmortem = incident.jira_postmortem_for
     logger.info(
-        f"Syncing key events timeline to Jira post-mortem {jira_postmortem.jira_issue_key} "
+        f"Syncing timeline to Jira post-mortem {jira_postmortem.jira_issue_key} "
         f"for incident #{incident.id}"
     )
 
@@ -61,7 +61,7 @@ def sync_key_events_to_jira_postmortem(
         # Generate updated timeline from template
         timeline_content = render_to_string(
             "jira/postmortem/timeline.txt",
-            {"incident": incident_refreshed},
+            {"timeline_rows": build_timeline_rows(incident_refreshed)},
         )
 
         # Get the field ID for timeline from service
@@ -86,3 +86,20 @@ def sync_key_events_to_jira_postmortem(
             f"Failed to update timeline in Jira post-mortem {jira_postmortem.jira_issue_key} "
             f"for incident #{incident.id}"
         )
+
+
+@receiver(signal=incident_key_events_updated)
+def sync_key_events_to_jira_postmortem(
+    sender: Any, incident: Incident, **kwargs: dict[str, Any]
+) -> None:
+    """Update Jira post-mortem timeline when key events are updated.
+
+    This handler is triggered when incident key events are updated via the web UI
+    or Slack, and syncs the timeline to the associated Jira post-mortem ticket.
+
+    Args:
+        sender: The sender of the signal
+        incident: The incident whose key events were updated
+        **kwargs: Additional keyword arguments
+    """
+    sync_timeline_to_jira_postmortem(incident)

--- a/src/firefighter/jira_app/templates/jira/postmortem/timeline.txt
+++ b/src/firefighter/jira_app/templates/jira/postmortem/timeline.txt
@@ -1,7 +1,5 @@
 h2. Timeline
 
 || Time || Event ||
-| {{ incident.created_at|date:"Y-m-d H:i" }} UTC | Incident created ({{ incident.priority.name }}) |
-{% for update in incident.incidentupdate_set.all|dictsort:"event_ts" %}{% if update.status %}| {{ update.event_ts|date:"Y-m-d H:i" }} UTC | Status changed to: {{ update.status.label }} |
-{% endif %}{% if update.event_type %}| {{ update.event_ts|date:"Y-m-d H:i" }} UTC | Key event: {{ update.event_type|title }}{% if update.message %} - {{ update.message }}{% endif %} |
-{% endif %}{% endfor %}
+{% for row in timeline_rows %}| {{ row.event_ts|date:"Y-m-d H:i T" }} | {{ row.label }} |
+{% endfor %}

--- a/src/firefighter/slack/models/conversation.py
+++ b/src/firefighter/slack/models/conversation.py
@@ -305,7 +305,9 @@ class Conversation(models.Model):
         if strategy == SlackMessageStrategy.APPEND:
             strategy_res = self._send_message_strategy_append(message, client, kwargs)
         elif strategy == SlackMessageStrategy.UPDATE:
-            strategy_res = self._send_message_strategy_update(message, client, kwargs)
+            strategy_res = self._send_message_strategy_update(
+                message, client, kwargs, strategy_args
+            )
         elif strategy == SlackMessageStrategy.REPLACE:
             strategy_res = self._send_message_strategy_replace(
                 message, client, strategy_args, kwargs
@@ -353,8 +355,28 @@ class Conversation(models.Model):
         return res
 
     def _send_message_strategy_update(
-        self, message: SlackMessageSurface, client: WebClient, kwargs: dict[str, Any]
+        self,
+        message: SlackMessageSurface,
+        client: WebClient,
+        kwargs: dict[str, Any],
+        strategy_args: dict[str, Any] | None = None,
     ) -> SlackResponse:
+        """Update in place the last message with the same type.
+
+        When `strategy_args` carries an explicit `ts`/`channel_id` (e.g. from
+        the interaction payload of the button that was clicked), that exact
+        message is targeted instead of looked up - needed when more than one
+        message of this type can legitimately coexist (e.g. a resolved review
+        message and a newer, unrelated pending one), where "the last one"
+        would not necessarily be the message actually being resolved.
+        """
+        if strategy_args is not None and strategy_args.get("ts") is not None:
+            return client.chat_update(
+                channel=strategy_args.get("channel_id", self.channel_id),
+                ts=strategy_args["ts"],
+                **message.get_slack_message_params(),
+            )
+
         old_message = (
             self._get_message_manager()
             .filter(ff_type=message.id, conversation=self)

--- a/src/firefighter/slack/views/modals/__init__.py
+++ b/src/firefighter/slack/views/modals/__init__.py
@@ -22,6 +22,9 @@ from firefighter.slack.views.modals.opening.check_current_incidents import (
 )
 from firefighter.slack.views.modals.opening.select_impact import modal_select_impact
 from firefighter.slack.views.modals.postmortem import PostMortemModal, modal_postmortem
+from firefighter.slack.views.modals.review_timeline import (  # XXX(dugab) move and rename (not a modal but a surface...)
+    SlackMessageReviewTimeline,
+)
 from firefighter.slack.views.modals.select import modal_select
 from firefighter.slack.views.modals.send_sos import SendSosModal, modal_send_sos
 from firefighter.slack.views.modals.status import StatusModal, modal_status

--- a/src/firefighter/slack/views/modals/base_modal/base.py
+++ b/src/firefighter/slack/views/modals/base_modal/base.py
@@ -51,6 +51,11 @@ app = SlackApp()
 logger = logging.getLogger(__name__)
 
 
+def _concat_validation_errors_msg(err: list[ValidationError]) -> str:
+    """Return a string of all validation errors."""
+    return reduce(operator.add, ["; ".join(e.messages) for e in err], "")
+
+
 class SlackModal:
     """Two main responsibilities:
     - Register the modal on Slack to open it with shortcuts or actions
@@ -303,17 +308,12 @@ class ModalForm[T: Form](SlackModal):
             ack(
                 response_action="errors",
                 errors={
-                    k: self._concat_validation_errors_msg(v)
+                    k: _concat_validation_errors_msg(v)
                     for k, v in form.errors.as_data().items()
                 },
             )
             return None
         return slack_form
-
-    @staticmethod
-    def _concat_validation_errors_msg(err: list[ValidationError]) -> str:
-        """Return a string of all validation errors."""
-        return reduce(operator.add, ["; ".join(e.messages) for e in err], "")
 
 
 class MessageForm[T: Form](SlackModal):
@@ -347,6 +347,10 @@ class MessageForm[T: Form](SlackModal):
             logger.warning("Form errors in Slack context.")
             logger.warning(form.errors.as_data())
 
-            ack(text="Error", response_type="ephemeral")
+            error_text = "; ".join(
+                f"{field}: {_concat_validation_errors_msg(errs)}"
+                for field, errs in form.errors.as_data().items()
+            )
+            ack(text=f"Error: {error_text}", response_type="ephemeral")
 
         return slack_form

--- a/src/firefighter/slack/views/modals/key_event_message.py
+++ b/src/firefighter/slack/views/modals/key_event_message.py
@@ -113,10 +113,10 @@ class KeyEvents(MessageForm[IncidentUpdateKeyEventsForm]):
         if form is None:
             logger.warning("Form is None, skipping save")
             return
+        self.form = form
         if len(form.errors) > 0:
             self.update_with_form()
             return
-        self.form = form
         self.form.save()
 
         # Send signal to update Jira post-mortem timeline if applicable

--- a/src/firefighter/slack/views/modals/opening/set_details.py
+++ b/src/firefighter/slack/views/modals/opening/set_details.py
@@ -12,7 +12,10 @@ from firefighter.firefighter.utils import get_in
 from firefighter.incidents.forms.create_incident import CreateIncidentFormBase
 from firefighter.incidents.models.priority import Priority
 from firefighter.incidents.signals import create_incident_conversation
-from firefighter.slack.views.modals.base_modal.base import ModalForm
+from firefighter.slack.views.modals.base_modal.base import (
+    ModalForm,
+    _concat_validation_errors_msg,
+)
 from firefighter.slack.views.modals.base_modal.form_utils import (
     SlackFormJSONEncoder,
     slack_view_submission_to_dict,
@@ -130,7 +133,7 @@ class SetIncidentDetails[T: CreateIncidentFormBase](ModalForm[T]):
             ack(
                 response_action="errors",
                 errors={
-                    k: self._concat_validation_errors_msg(v)
+                    k: _concat_validation_errors_msg(v)
                     for k, v in form.errors.as_data().items()
                 },
             )

--- a/src/firefighter/slack/views/modals/review_timeline.py
+++ b/src/firefighter/slack/views/modals/review_timeline.py
@@ -18,13 +18,17 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from django.utils.timezone import localtime
-from slack_sdk.models.blocks import Block, HeaderBlock, SectionBlock
+from django.utils.timezone import localtime, now
+from slack_sdk.models.blocks import Block, ContextBlock, HeaderBlock, SectionBlock
+from slack_sdk.models.blocks.basic_components import MarkdownTextObject
 from slack_sdk.models.blocks.block_elements import ButtonElement
 from slack_sdk.models.blocks.blocks import ActionsBlock
 
 from firefighter.incidents.enums import IncidentStatus
-from firefighter.incidents.forms.timeline_correction import TimelineCorrectionForm
+from firefighter.incidents.forms.timeline_correction import (
+    DEFINITIVE_OCCURRENCE,
+    TimelineCorrectionForm,
+)
 from firefighter.incidents.models.incident import Incident
 from firefighter.incidents.signals import incident_key_events_updated
 from firefighter.slack.messages.base import SlackMessageStrategy, SlackMessageSurface
@@ -46,6 +50,7 @@ app = SlackApp()
 
 ACCEPT_ACTION_ID = "review_timeline_accept"
 REJECT_ACTION_ID = "review_timeline_reject"
+RECHECK_ACTION_ID = "review_timeline_recheck"
 
 # Fields carried over from the Update Status submission so they aren't lost
 # while the human reviews the timeline (mirrors utils._build_carry_over_from_form).
@@ -123,6 +128,30 @@ class TimelineEntry(NamedTuple):
 # status timeline - both are collected via the Key Events form (see
 # fixtures/incidents/milestone_type.json) but aren't guaranteed to be filled
 # in, since that form is user-editable and can be skipped.
+# The expected chronological order of an incident, spanning both milestones and
+# status transitions. This interleaving lives nowhere else: MilestoneType has no
+# `order` field and IncidentStatus only orders the statuses among themselves.
+# Single source of truth for the displayed legend and the consistency checks.
+# label, emoji, source key, and which occurrence to keep when a status repeats
+# after a reopen: investigation *started* at its first occurrence, while the
+# mitigation that actually held is the last one - and that is the one the
+# post-mortem timeline must show.
+# label, emoji, source, and whether a missing time is an error. Only the
+# milestones are mandatory (MilestoneType.required): a status that never
+# happened - an incident going straight from Declared to Mitigated, say - is
+# not a mistake and must not be reported as one.
+_EXPECTED_STEPS: tuple[tuple[str, str, str | IncidentStatus, bool], ...] = (
+    ("Started", ":firecracker:", "started", True),
+    ("Detected", ":eyes:", "detected", True),
+    ("Declared", ":loudspeaker:", IncidentStatus.OPEN, False),
+    ("Investigating", ":mag:", IncidentStatus.INVESTIGATING, False),
+    ("Mitigating", ":wrench:", IncidentStatus.MITIGATING, False),
+    ("Mitigated", ":white_check_mark:", IncidentStatus.MITIGATED, False),
+    ("Post-mortem", ":memo:", IncidentStatus.POST_MORTEM, False),
+)
+
+_EXPECTED_ORDER: tuple[str, ...] = tuple(label for label, *_ in _EXPECTED_STEPS)
+
 _MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
     ("started", "Started"),
     ("detected", "Detected"),
@@ -170,6 +199,103 @@ def get_incident_timeline(incident: Incident) -> list[TimelineEntry]:
     return [*milestones, *status_entries]
 
 
+class TimelineIssue(NamedTuple):
+    label: str
+    message: str
+
+
+def _format_delta(delta: datetime.timedelta) -> str:
+    seconds = int(abs(delta).total_seconds())
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    parts = [
+        f"{value}{unit}"
+        for value, unit in ((days, "d"), (hours, "h"), (minutes, "m"), (seconds, "s"))
+        if value
+    ]
+    return " ".join(parts[:2]) if parts else "0s"
+
+
+class TimelineStep(NamedTuple):
+    label: str
+    emoji: str
+    event_ts: datetime.datetime | None
+    occurrences: int
+    required: bool
+
+
+def get_canonical_steps(incident: Incident) -> list[TimelineStep]:
+    """One step per `_EXPECTED_STEPS` entry, collapsing reopen cycles.
+
+    A reopened incident goes through Investigating/Mitigating/Mitigated more than
+    once. Listing every occurrence makes the sequence impossible to check against
+    the expected order and buries the definitive times, so each step keeps a
+    single timestamp and carries its occurrence count instead.
+    """
+    milestone_updates = dict(
+        incident.incidentupdate_set.filter(
+            event_type__in=[event_type for event_type, _ in _MILESTONE_EVENT_TYPES]
+        )
+        .order_by("event_ts")
+        .values_list("event_type", "event_ts")
+    )
+    status_occurrences: dict[IncidentStatus, list[datetime.datetime]] = {}
+    for status, event_ts in get_status_timeline(incident):
+        status_occurrences.setdefault(status, []).append(event_ts)
+
+    steps: list[TimelineStep] = []
+    for label, emoji, source, required in _EXPECTED_STEPS:
+        step_ts: datetime.datetime | None
+        if isinstance(source, str):
+            step_ts = milestone_updates.get(source)
+            count = 1 if step_ts is not None else 0
+        else:
+            stamps = sorted(status_occurrences.get(source) or [])
+            count = len(stamps)
+            which = DEFINITIVE_OCCURRENCE.get(source, "last")
+            step_ts = (stamps[-1] if which == "last" else stamps[0]) if stamps else None
+        steps.append(TimelineStep(label, emoji, step_ts, count, required))
+    return steps
+
+
+def find_timeline_issues(steps: list[TimelineStep]) -> list[TimelineIssue]:
+    """Checks the recorded steps against the expected chronology.
+
+    Reports steps that break the order, required steps with no recorded time,
+    and times in the future - the three ways a hand-typed timeline goes wrong.
+    """
+    issues: list[TimelineIssue] = []
+    right_now = now()
+    previous: tuple[str, datetime.datetime] | None = None
+    for step in steps:
+        label = step.label
+        event_ts = step.event_ts
+        if event_ts is None:
+            if step.required:
+                issues.append(
+                    TimelineIssue(
+                        label, f"*{label}* is required and has no recorded time"
+                    )
+                )
+            continue
+        if event_ts > right_now:
+            issues.append(
+                TimelineIssue(label, f"*{label}* is in the future")
+            )
+        if previous is not None and event_ts < previous[1]:
+            issues.append(
+                TimelineIssue(
+                    label,
+                    f"*{label}* ({localtime(event_ts).strftime('%H:%M:%S')}) is "
+                    f"{_format_delta(previous[1] - event_ts)} before *{previous[0]}* "
+                    f"({localtime(previous[1]).strftime('%H:%M:%S')})",
+                )
+            )
+        previous = (label, event_ts)
+    return issues
+
+
 class SlackMessageReviewTimeline(SlackMessageSurface):
     id = "ff_incident_timeline_review"
     # Each new pending review posts fresh and removes the previous review
@@ -197,16 +323,78 @@ class SlackMessageReviewTimeline(SlackMessageSurface):
         return f"Timeline review before Post-mortem for {self.incident}."
 
     def get_blocks(self) -> list[Block]:
-        blocks: list[Block] = [
-            HeaderBlock(text=":stopwatch: Timeline Review"),
-        ]
-        for entry in get_incident_timeline(self.incident):
-            value = (
-                localtime(entry.event_ts).strftime("%Y-%m-%d %H:%M:%S %Z")
-                if entry.event_ts is not None
-                else "_Not recorded_"
+        steps = get_canonical_steps(self.incident)
+        issues = find_timeline_issues(steps)
+        flagged = {issue.label for issue in issues}
+
+        recorded = sorted(
+            localtime(step.event_ts) for step in steps if step.event_ts is not None
+        )
+        dates = {ts.date() for ts in recorded}
+        # Incidents can span several days, so the date is never dropped: a single
+        # day goes in the heading and the rows carry times only, otherwise the
+        # heading carries the range and every row carries its own day.
+        single_day = len(dates) == 1
+        heading = ":stopwatch: Timeline Review"
+        if recorded:
+            first, last = recorded[0].date(), recorded[-1].date()
+            if single_day:
+                span = first.strftime("%d %b %Y")
+            elif (first.year, first.month) == (last.year, last.month):
+                span = f"{first.day} → {last.strftime('%d %b %Y')}"
+            elif first.year == last.year:
+                span = f"{first.strftime('%d %b')} → {last.strftime('%d %b %Y')}"
+            else:
+                span = f"{first.strftime('%d %b %Y')} → {last.strftime('%d %b %Y')}"
+            heading = f"{heading} — {span} ({recorded[0].strftime('%Z')})"
+
+        blocks: list[Block] = [HeaderBlock(text=heading)]
+
+        # Horizontal chain: reads as a timeline at a glance and wraps on its own
+        # in Slack. Times are minute-precision here to keep the chain short - the
+        # exact seconds are in the issue list below and in the correction form.
+        chain = []
+        for step in steps:
+            if step.event_ts is None and not step.required:
+                continue
+            if step.event_ts is None:
+                stamp = "_not recorded_"
+            else:
+                local = localtime(step.event_ts)
+                stamp = local.strftime("%H:%M" if single_day else "%d/%m %H:%M")
+            marks = " :warning:" if step.label in flagged else ""
+            reopened = f" ↻{step.occurrences - 1}" if step.occurrences > 1 else ""
+            chain.append(f"{step.emoji} *{step.label}* {stamp}{marks}{reopened}")
+        blocks.append(SectionBlock(text="  ➜  ".join(chain)))
+
+        if issues:
+            details = "\n".join(f"> • {issue.message}" for issue in issues)
+            blocks.append(
+                SectionBlock(
+                    text=(
+                        f":warning: *{len(issues)} issue"
+                        f"{'s' if len(issues) > 1 else ''} to fix before "
+                        f"continuing*\n{details}"
+                    )
+                )
             )
-            blocks.append(SectionBlock(text=f"• *{entry.label}*: {value}"))
+        elif self.resolution is None:
+            blocks.append(
+                SectionBlock(
+                    text=":white_check_mark: *No inconsistency detected* — order and recorded times are consistent."
+                )
+            )
+
+        blocks.append(
+            ContextBlock(
+                elements=[
+                    MarkdownTextObject(
+                        text="Expected order: " + " → ".join(_EXPECTED_ORDER)
+                        + "   ·   ↻ = reopen cycles"
+                    )
+                ]
+            )
+        )
 
         if self.resolution == "accepted":
             blocks.append(
@@ -225,23 +413,28 @@ class SlackMessageReviewTimeline(SlackMessageSurface):
                 )
             )
         else:
-            blocks.append(
-                ActionsBlock(
-                    elements=[
-                        ButtonElement(
-                            text="Looks correct — continue to Post-mortem",
-                            style="primary",
-                            action_id=ACCEPT_ACTION_ID,
-                            value=self.carry_over_payload,
-                        ),
-                        ButtonElement(
-                            text="Not accurate — let me fix it",
-                            action_id=REJECT_ACTION_ID,
-                            value=self.carry_over_payload,
-                        ),
-                    ]
+            # Accept is withheld while the timeline is inconsistent: a wrong
+            # timeline drives the post-mortem and the incident metrics. Slack
+            # cannot disable a button, so it is simply not rendered - the accept
+            # handler re-checks as well, since an older message stays clickable.
+            actions = []
+            if not issues:
+                actions.append(
+                    ButtonElement(
+                        text="Looks correct — continue to Post-mortem",
+                        style="primary",
+                        action_id=ACCEPT_ACTION_ID,
+                        value=self.carry_over_payload,
+                    )
+                )
+            actions.append(
+                ButtonElement(
+                    text="Not accurate — let me fix it",
+                    action_id=REJECT_ACTION_ID,
+                    value=self.carry_over_payload,
                 )
             )
+            blocks.append(ActionsBlock(elements=actions))
         return blocks
 
 
@@ -265,6 +458,25 @@ def _resolved_message_strategy_args(body: dict[str, Any]) -> dict[str, Any] | No
 @app.action(ACCEPT_ACTION_ID)
 def handle_review_timeline_accept(ack: Ack, body: dict[str, Any]) -> None:
     ack()
+    _resolve_timeline_and_transition(body, update_in_place=True)
+
+
+@app.action(RECHECK_ACTION_ID)
+def handle_review_timeline_recheck(ack: Ack, body: dict[str, Any]) -> None:
+    """Re-run the checks from the correction message and transition if clean.
+
+    Saves a round trip through the Update Status modal once the times are fixed.
+    The transition it applies carries the status only: the message and any
+    priority or category change from the original submission cannot be threaded
+    across the correction step, so nothing pretends to carry them.
+    """
+    ack()
+    _resolve_timeline_and_transition(body, update_in_place=False)
+
+
+def _resolve_timeline_and_transition(
+    body: dict[str, Any], *, update_in_place: bool
+) -> None:
     payload = _parse_action_payload(body)
     if payload is None:
         return
@@ -275,15 +487,38 @@ def handle_review_timeline_accept(ack: Ack, body: dict[str, Any]) -> None:
         respond(body, text=":x: Incident not found.")
         return
 
+    # Re-check server-side: the button is not rendered when the timeline is
+    # inconsistent, but an older review message left in the channel stays
+    # clickable, so the gate cannot live in the rendering alone.
+    issues = find_timeline_issues(get_canonical_steps(incident))
+    if issues:
+        respond(
+            body,
+            text=(
+                ":warning: The timeline still has "
+                f"{len(issues)} issue{'s' if len(issues) > 1 else ''} to fix: "
+                + "; ".join(issue.message for issue in issues)
+            ),
+        )
+        return
+
     user = get_user_from_context(body)
+    # Flush the edits made in the correction form now that the reviewer is done:
+    # this refreshes the Key Events form message (it shows the same milestones)
+    # and re-syncs the Jira timeline, once instead of once per keystroke.
+    incident_key_events_updated.send_robust(__name__, incident=incident)
     incident.create_incident_update(
         created_by=user, status=IncidentStatus.POST_MORTEM, **payload
     )
     _push_confirmed_timeline_to_jira(incident)
+    # Accept edits the review message it was clicked from; the re-check button
+    # lives on the correction message, so it posts the outcome as a new message
+    # rather than overwriting a form the reviewer may still be reading.
+    strategy_args = _resolved_message_strategy_args(body) if update_in_place else None
     incident.conversation.send_message_and_save(
         SlackMessageReviewTimeline(incident, resolution="accepted"),
-        strategy=SlackMessageStrategy.UPDATE,
-        strategy_args=_resolved_message_strategy_args(body),
+        strategy=SlackMessageStrategy.UPDATE if update_in_place else SlackMessageStrategy.APPEND,
+        strategy_args=strategy_args,
     )
 
 
@@ -342,19 +577,33 @@ class TimelineCorrection(MessageForm[TimelineCorrectionForm]):
         slack_form: SlackForm[TimelineCorrectionForm] = self.get_form_class()
         slack_form.form = form
         blocks += slack_form.slack_blocks()
+        # Deliberately not an "accept" button: it re-runs the checks and only
+        # transitions if they pass. Its payload is the incident id alone - the
+        # original Update Status submission (its message, any priority or
+        # category change) cannot be threaded across the correction step, and
+        # this way nothing pretends to carry it.
         blocks.append(
             ActionsBlock(
                 elements=[
                     ButtonElement(
-                        text="Looks correct — continue to Post-mortem",
+                        text="Re-check timeline & continue to Post-mortem",
                         style="primary",
-                        action_id=ACCEPT_ACTION_ID,
-                        # Minimal payload (just the incident id), regenerated
-                        # fresh on every render - avoids needing to carry the
-                        # original Update Status submission's payload across
-                        # an indefinite number of field-edit reposts.
+                        action_id=RECHECK_ACTION_ID,
                         value=build_carry_over_payload(form.incident, {}),
                     ),
+                ]
+            )
+        )
+        blocks.append(
+            ContextBlock(
+                elements=[
+                    MarkdownTextObject(
+                        text=(
+                            "Re-checking applies the status change only. To also "
+                            "post an update message, run *Update Status* → "
+                            "*Post-mortem* instead."
+                        )
+                    )
                 ]
             )
         )
@@ -376,17 +625,20 @@ class TimelineCorrection(MessageForm[TimelineCorrectionForm]):
             return
         self.form.save()
 
-        # Same side effects as the Key Events form: refresh the Jira
-        # post-mortem timeline and the incident's computed metrics.
-        incident_key_events_updated.send_robust(__name__, incident=incident)
+        # Metrics are cheap and local, so they stay in sync on every edit.
         incident.compute_metrics()
 
-        # Only the correction message itself needs refreshing here - this
-        # runs on every single field edit (like Key Events), so reposting
-        # the "rejected" review message too would move/repost it on every
-        # keystroke. That message already showed why the review was
-        # rejected; the corrected timeline becomes visible in a fresh review
-        # message the next time Update Status -> Post-mortem is submitted.
+        # `incident_key_events_updated` is deliberately NOT sent here. This
+        # method runs on every single field edit, and the signal fans out to a
+        # Jira round trip plus a refresh of the Key Events form message - which
+        # shows the same started/detected values, so Slack marks it "(edited)"
+        # and resurfaces it on every keystroke. Both are done once the reviewer
+        # is finished, from `_resolve_timeline_and_transition`, which keeps the
+        # two surfaces consistent without the noise (and without ~2 Jira calls
+        # per edited field).
+        #
+        # Only the correction message itself is refreshed here, to echo the
+        # value that was just saved.
         self.update_with_form()
 
     def update_with_form(self) -> None:

--- a/src/firefighter/slack/views/modals/review_timeline.py
+++ b/src/firefighter/slack/views/modals/review_timeline.py
@@ -1,0 +1,442 @@
+"""Timeline review checkpoint shown before an incident moves to Post-mortem.
+
+This does not change how the timeline is recorded today — every status
+change still comes from the normal Update Status modal. It only inserts a
+confirmation step right before the Post-mortem transition, showing the
+timeline as already recorded and letting a human accept it (the transition
+then proceeds normally, and the confirmed timeline is pushed into the
+incident's Jira post-mortem "Timeline" field, if any) or reject it (the
+transition is cancelled, and a correction message - same pattern as the Key
+Events message - lets the human edit the recorded times directly, each
+change saving immediately).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from django.utils.timezone import localtime
+from slack_sdk.models.blocks import Block, HeaderBlock, SectionBlock
+from slack_sdk.models.blocks.block_elements import ButtonElement
+from slack_sdk.models.blocks.blocks import ActionsBlock
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.forms.timeline_correction import TimelineCorrectionForm
+from firefighter.incidents.models.incident import Incident
+from firefighter.incidents.signals import incident_key_events_updated
+from firefighter.slack.messages.base import SlackMessageStrategy, SlackMessageSurface
+from firefighter.slack.slack_app import SlackApp
+from firefighter.slack.slack_incident_context import get_user_from_context
+from firefighter.slack.utils import respond
+from firefighter.slack.views.modals.base_modal.base import MessageForm
+
+if TYPE_CHECKING:
+    import datetime
+
+    from slack_bolt.context.ack.ack import Ack
+
+    from firefighter.incidents.models.user import User
+    from firefighter.slack.views.modals.base_modal.form_utils import SlackForm
+
+logger = logging.getLogger(__name__)
+app = SlackApp()
+
+ACCEPT_ACTION_ID = "review_timeline_accept"
+REJECT_ACTION_ID = "review_timeline_reject"
+
+# Fields carried over from the Update Status submission so they aren't lost
+# while the human reviews the timeline (mirrors utils._build_carry_over_from_form).
+# "status" is deliberately excluded: the accept handler always sets it to
+# IncidentStatus.POST_MORTEM explicitly.
+_CARRY_OVER_FIELDS: tuple[str, ...] = (
+    "priority_id",
+    "incident_category_id",
+    "message",
+    "title",
+    "description",
+)
+
+
+def build_carry_over_payload(incident: Incident, update_kwargs: dict[str, Any]) -> str:
+    """Serialize the incident id and carried-over form fields into a button value."""
+    payload: dict[str, Any] = {"incident_id": incident.id}
+    for field in _CARRY_OVER_FIELDS:
+        if field in update_kwargs:
+            value = update_kwargs[field]
+            payload[field] = str(value) if field.endswith("_id") else value
+    return json.dumps(payload)
+
+
+def _parse_action_payload(body: dict[str, Any]) -> dict[str, Any] | None:
+    actions = body.get("actions") or []
+    if not actions:
+        return None
+    raw_value = actions[0].get("value")
+    if not raw_value:
+        return None
+    try:
+        return json.loads(raw_value)
+    except (TypeError, ValueError):
+        logger.exception("Could not parse review timeline action payload: %s", raw_value)
+        return None
+
+
+def get_status_timeline(incident: Incident) -> list[tuple[IncidentStatus, datetime.datetime]]:
+    """Every status transition, in chronological order, including reopen cycles.
+
+    The declaration `OPEN` row always anchors to `incident.created_at` (the
+    incident's true start), never to whichever `OPEN` row happens to be
+    latest - so it's added explicitly rather than trusted from the DB row.
+    An incident can legitimately go back to `OPEN` later (a real reopen);
+    that row has a different `event_ts` than `created_at` and is kept, so it
+    shows up as its own entry rather than being silently dropped. Every
+    other status contributes one entry per row - a status revisited after a
+    reopen (MITIGATED -> INVESTIGATING/MITIGATING) shows every visit,
+    matching the full audit trail rendered in the Jira post-mortem timeline.
+    """
+    timeline: list[tuple[IncidentStatus, datetime.datetime]] = [
+        (IncidentStatus.OPEN, incident.created_at)
+    ]
+    updates = incident.incidentupdate_set.filter(_status__isnull=False).order_by(
+        "event_ts"
+    )
+    for update in updates:
+        status = update.status
+        if status is None:
+            continue
+        if status == IncidentStatus.OPEN and update.event_ts == incident.created_at:
+            continue  # already represented by the anchor above
+        timeline.append((status, update.event_ts))
+    return sorted(timeline, key=lambda item: item[1])
+
+
+class TimelineEntry(NamedTuple):
+    label: str
+    event_ts: datetime.datetime | None
+    """None if this milestone was never recorded via the Key Events form."""
+
+
+# (event_type, display label), in the order they should appear before the
+# status timeline - both are collected via the Key Events form (see
+# fixtures/incidents/milestone_type.json) but aren't guaranteed to be filled
+# in, since that form is user-editable and can be skipped.
+_MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
+    ("started", "Started"),
+    ("detected", "Detected"),
+)
+
+
+def get_incident_timeline(incident: Incident) -> list[TimelineEntry]:
+    """Started/Detected milestones (if recorded), followed by the status timeline.
+
+    Milestones missing a recorded `event_ts` are still included, with
+    `event_ts=None`, so the reviewer notices the gap rather than the
+    milestone silently disappearing from the list. The milestone group
+    itself is sorted chronologically (Detected can legitimately be recorded
+    before Started, e.g. an automated alert fires before the actual start is
+    pinpointed) - unrecorded milestones sort last within the group, since
+    there's no time to place them by. The group as a whole always leads the
+    status timeline, since milestones routinely predate the incident being
+    declared in FireFighter. Only the first `OPEN` entry (the one anchored to
+    `incident.created_at`) is relabeled "Declared" - a later `OPEN` entry is
+    a genuine reopen and keeps reading "Open".
+    """
+    milestone_updates = dict(
+        incident.incidentupdate_set.filter(
+            event_type__in=[event_type for event_type, _ in _MILESTONE_EVENT_TYPES]
+        )
+        .order_by("event_ts")
+        .values_list("event_type", "event_ts")
+    )
+    milestones = sorted(
+        (
+            TimelineEntry(label=label, event_ts=milestone_updates.get(event_type))
+            for event_type, label in _MILESTONE_EVENT_TYPES
+        ),
+        key=lambda entry: (entry.event_ts is None, entry.event_ts),
+    )
+    status_entries = []
+    declared_shown = False
+    for status, event_ts in get_status_timeline(incident):
+        if status == IncidentStatus.OPEN and not declared_shown:
+            label = "Declared"
+            declared_shown = True
+        else:
+            label = status.label
+        status_entries.append(TimelineEntry(label=label, event_ts=event_ts))
+    return [*milestones, *status_entries]
+
+
+class SlackMessageReviewTimeline(SlackMessageSurface):
+    id = "ff_incident_timeline_review"
+    # Each new pending review posts fresh and removes the previous review
+    # message for this incident (REPLACE) - not an edit of a previous,
+    # possibly long-buried one (e.g. a prior rejection, with a lot of channel
+    # activity since). Resolving a review (Accept/Reject) still updates that
+    # specific message in place, but does so by explicitly targeting the
+    # clicked message - see `_resolved_message_strategy_args` - rather than
+    # relying on this class-level strategy.
+    strategy: SlackMessageStrategy = SlackMessageStrategy.REPLACE
+
+    def __init__(
+        self,
+        incident: Incident,
+        carry_over_payload: str | None = None,
+        resolution: str | None = None,
+    ) -> None:
+        """`resolution` is None while pending, or "accepted"/"rejected" once resolved."""
+        self.incident = incident
+        self.carry_over_payload = carry_over_payload
+        self.resolution = resolution
+        super().__init__()
+
+    def get_text(self) -> str:
+        return f"Timeline review before Post-mortem for {self.incident}."
+
+    def get_blocks(self) -> list[Block]:
+        blocks: list[Block] = [
+            HeaderBlock(text=":stopwatch: Timeline Review"),
+        ]
+        for entry in get_incident_timeline(self.incident):
+            value = (
+                localtime(entry.event_ts).strftime("%Y-%m-%d %H:%M:%S %Z")
+                if entry.event_ts is not None
+                else "_Not recorded_"
+            )
+            blocks.append(SectionBlock(text=f"• *{entry.label}*: {value}"))
+
+        if self.resolution == "accepted":
+            blocks.append(
+                SectionBlock(
+                    text=":white_check_mark: Timeline accepted — incident moved to Post-mortem."
+                )
+            )
+        elif self.resolution == "rejected":
+            blocks.append(
+                SectionBlock(
+                    text=(
+                        ":x: Timeline not accepted — the Post-mortem transition was cancelled.\n"
+                        "Correct the recorded times in the message below, then update the "
+                        "status to *Post-mortem* again."
+                    )
+                )
+            )
+        else:
+            blocks.append(
+                ActionsBlock(
+                    elements=[
+                        ButtonElement(
+                            text="Looks correct — continue to Post-mortem",
+                            style="primary",
+                            action_id=ACCEPT_ACTION_ID,
+                            value=self.carry_over_payload,
+                        ),
+                        ButtonElement(
+                            text="Not accurate — let me fix it",
+                            action_id=REJECT_ACTION_ID,
+                            value=self.carry_over_payload,
+                        ),
+                    ]
+                )
+            )
+        return blocks
+
+
+def _resolved_message_strategy_args(body: dict[str, Any]) -> dict[str, Any] | None:
+    """Target the exact message that was clicked, from the interaction payload.
+
+    "Last message of this type" (the fallback when this returns None) is
+    usually correct, since REPLACE removes the previous review message when
+    a new one is posted - but explicit targeting is still more direct and
+    avoids relying on that being true. Returns None if the payload doesn't
+    carry the expected fields (e.g. in tests), in which case the caller
+    falls back to the ff_type lookup.
+    """
+    message_ts = (body.get("container") or {}).get("message_ts")
+    channel_id = (body.get("channel") or {}).get("id")
+    if message_ts is None or channel_id is None:
+        return None
+    return {"ts": message_ts, "channel_id": channel_id}
+
+
+@app.action(ACCEPT_ACTION_ID)
+def handle_review_timeline_accept(ack: Ack, body: dict[str, Any]) -> None:
+    ack()
+    payload = _parse_action_payload(body)
+    if payload is None:
+        return
+    incident_id = payload.pop("incident_id")
+    try:
+        incident = Incident.objects.get(pk=incident_id)
+    except Incident.DoesNotExist:
+        respond(body, text=":x: Incident not found.")
+        return
+
+    user = get_user_from_context(body)
+    incident.create_incident_update(
+        created_by=user, status=IncidentStatus.POST_MORTEM, **payload
+    )
+    _push_confirmed_timeline_to_jira(incident)
+    incident.conversation.send_message_and_save(
+        SlackMessageReviewTimeline(incident, resolution="accepted"),
+        strategy=SlackMessageStrategy.UPDATE,
+        strategy_args=_resolved_message_strategy_args(body),
+    )
+
+
+def _push_confirmed_timeline_to_jira(incident: Incident) -> None:
+    """Push the just-accepted timeline into the incident's Jira post-mortem, if any.
+
+    Guarded by an app-installed check, not just the ENABLE_JIRA_POSTMORTEM
+    setting: `firefighter.jira_app` is only added to INSTALLED_APPS when Jira
+    is enabled (see settings/components/jira_app.py), so importing its models
+    when the app isn't installed would be unsafe. This keeps `slack` free of
+    a hard dependency on `jira_app` being present.
+    """
+    from django.apps import apps
+
+    if not apps.is_installed("firefighter.jira_app"):
+        return
+
+    from firefighter.jira_app.signals import sync_timeline_to_jira_postmortem
+
+    sync_timeline_to_jira_postmortem(incident)
+
+
+# Matches this form's field names (milestone_started, status_<uuid>, ...) so
+# touching any of its datetimepickers routes here - mirrors key_event_message's
+# MILESTONE_ID_REGEX, kept distinct from it to avoid any ambiguity between the
+# two forms' action ids.
+TIMELINE_CORRECTION_ID_REGEX = re.compile(r"^(milestone|status)_.*$")
+
+
+class TimelineCorrection(MessageForm[TimelineCorrectionForm]):
+    """Correction message, same pattern as Key Events: edit a field, it saves immediately.
+
+    Chosen over a modal because a modal's fixed height makes many fields
+    (2 milestones + one per status reached) cramped and scroll-heavy; a
+    channel message doesn't have that constraint and matches a surface
+    users are already familiar with.
+    """
+
+    form_class = TimelineCorrectionForm
+    callback_id = TIMELINE_CORRECTION_ID_REGEX
+    callback_action = True
+
+    def build_modal_fn(self, incident: Incident) -> list[Block]:
+        slack_form: SlackForm[TimelineCorrectionForm] = self.get_form_class()(
+            incident=incident
+        )
+        return self.get_blocks_from_form(slack_form.form)
+
+    def get_blocks_from_form(self, form: TimelineCorrectionForm) -> list[Block]:
+        blocks: list[Block] = [
+            HeaderBlock(text=":stopwatch: Correct the timeline"),
+            SectionBlock(
+                text="Edit any time below - each change saves immediately."
+            ),
+        ]
+        slack_form: SlackForm[TimelineCorrectionForm] = self.get_form_class()
+        slack_form.form = form
+        blocks += slack_form.slack_blocks()
+        blocks.append(
+            ActionsBlock(
+                elements=[
+                    ButtonElement(
+                        text="Looks correct — continue to Post-mortem",
+                        style="primary",
+                        action_id=ACCEPT_ACTION_ID,
+                        # Minimal payload (just the incident id), regenerated
+                        # fresh on every render - avoids needing to carry the
+                        # original Update Status submission's payload across
+                        # an indefinite number of field-edit reposts.
+                        value=build_carry_over_payload(form.incident, {}),
+                    ),
+                ]
+            )
+        )
+        return blocks
+
+    def handle_modal_fn(  # type: ignore[override]
+        self, ack: Ack, body: dict[str, Any], user: User, incident: Incident
+    ) -> None:
+        slack_form = self.handle_form_errors(
+            ack, body, forms_kwargs={"incident": incident, "user": user}
+        )
+        form = slack_form.form if slack_form else None
+        if form is None:
+            logger.warning("Form is None, skipping save")
+            return
+        self.form = form
+        if len(form.errors) > 0:
+            self.update_with_form()
+            return
+        self.form.save()
+
+        # Same side effects as the Key Events form: refresh the Jira
+        # post-mortem timeline and the incident's computed metrics.
+        incident_key_events_updated.send_robust(__name__, incident=incident)
+        incident.compute_metrics()
+
+        # Only the correction message itself needs refreshing here - this
+        # runs on every single field edit (like Key Events), so reposting
+        # the "rejected" review message too would move/repost it on every
+        # keystroke. That message already showed why the review was
+        # rejected; the corrected timeline becomes visible in a fresh review
+        # message the next time Update Status -> Post-mortem is submitted.
+        self.update_with_form()
+
+    def update_with_form(self) -> None:
+        self.form.incident.conversation.send_message_and_save(
+            SlackMessageTimelineCorrection(self.form.incident)
+        )
+
+
+timeline_correction_surface = TimelineCorrection()
+
+
+class SlackMessageTimelineCorrection(SlackMessageSurface):
+    id = "ff_incident_timeline_correction"
+    strategy: SlackMessageStrategy = SlackMessageStrategy.UPDATE
+
+    def __init__(self, incident: Incident) -> None:
+        self.incident = incident
+        super().__init__()
+
+    def get_blocks(self) -> list[Block]:
+        return TimelineCorrection().build_modal_fn(self.incident)
+
+    def get_text(self) -> str:
+        return f"Correct the timeline for {self.incident}."
+
+
+@app.action(REJECT_ACTION_ID)
+def handle_review_timeline_reject(ack: Ack, body: dict[str, Any]) -> None:
+    ack()
+    payload = _parse_action_payload(body)
+    if payload is None:
+        return
+    incident_id = payload["incident_id"]
+    try:
+        incident = Incident.objects.get(pk=incident_id)
+    except Incident.DoesNotExist:
+        respond(body, text=":x: Incident not found.")
+        return
+
+    incident.conversation.send_message_and_save(
+        SlackMessageReviewTimeline(incident, resolution="rejected"),
+        strategy=SlackMessageStrategy.UPDATE,
+        strategy_args=_resolved_message_strategy_args(body),
+    )
+    # REPLACE here (not the class default UPDATE) so a new reject cycle
+    # removes a stale correction message from a previous one, rather than
+    # editing it in place. Editing a single field within the same cycle
+    # (TimelineCorrection.update_with_form) still uses UPDATE - cheap,
+    # in-place, no need to delete/repost on every field change.
+    incident.conversation.send_message_and_save(
+        SlackMessageTimelineCorrection(incident),
+        strategy=SlackMessageStrategy.REPLACE,
+    )

--- a/src/firefighter/slack/views/modals/update_status.py
+++ b/src/firefighter/slack/views/modals/update_status.py
@@ -11,7 +11,10 @@ from firefighter.incidents.enums import IncidentStatus
 from firefighter.incidents.forms.update_status import UpdateStatusForm
 from firefighter.slack.slack_templating import slack_block_footer, slack_block_separator
 from firefighter.slack.views.modals.base_modal.base import ModalForm
-from firefighter.slack.views.modals.utils import handle_update_status_close_request
+from firefighter.slack.views.modals.utils import (
+    handle_update_status_close_request,
+    show_timeline_review,
+)
 
 if TYPE_CHECKING:
     from slack_bolt.context.ack.ack import Ack
@@ -138,19 +141,37 @@ class UpdateStatusModal(ModalForm[UpdateStatusFormSlack]):
                     )
                     return
 
+            # Before reaching Post-mortem, let a human review the recorded
+            # timeline and accept/reject it, instead of transitioning right away.
+            # Skipped when the incident has no post-mortem to review the
+            # timeline for (e.g. below P1/P2, or not in PRD).
+            if target_status == IncidentStatus.POST_MORTEM and incident.needs_postmortem:
+                update_kwargs = self._build_update_kwargs(form)
+                if len(update_kwargs) == 0:
+                    logger.warning("No update to incident status")
+                    ack()
+                    return
+                show_timeline_review(ack, incident, update_kwargs)
+                return
+
         # All validations passed, acknowledge the submission
         ack()
 
+        update_kwargs = self._build_update_kwargs(form)
+        if len(update_kwargs) == 0:
+            logger.warning("No update to incident status")
+            return
+        self._trigger_incident_workflow(incident, user, **update_kwargs)
+
+    @staticmethod
+    def _build_update_kwargs(form: UpdateStatusFormSlack) -> dict[str, Any]:
         update_kwargs: dict[str, Any] = {}
         for changed_key in form.changed_data:
             if changed_key in {"incident_category", "priority"}:
                 update_kwargs[f"{changed_key}_id"] = form.cleaned_data[changed_key].id
             if changed_key in {"description", "title", "message", "status"}:
                 update_kwargs[changed_key] = form.cleaned_data[changed_key]
-        if len(update_kwargs) == 0:
-            logger.warning("No update to incident status")
-            return
-        self._trigger_incident_workflow(incident, user, **update_kwargs)
+        return update_kwargs
 
     @staticmethod
     def _trigger_incident_workflow(

--- a/src/firefighter/slack/views/modals/utils.py
+++ b/src/firefighter/slack/views/modals/utils.py
@@ -6,6 +6,10 @@ from typing import TYPE_CHECKING, Any
 from firefighter.incidents.enums import IncidentStatus
 from firefighter.incidents.forms.update_status import UpdateStatusForm
 from firefighter.slack.views.modals.closure_reason import modal_closure_reason
+from firefighter.slack.views.modals.review_timeline import (
+    SlackMessageReviewTimeline,
+    build_carry_over_payload,
+)
 
 if TYPE_CHECKING:
     from django.forms import Form
@@ -73,6 +77,23 @@ def handle_update_status_close_request(
         return True
 
     return False
+
+
+def show_timeline_review(
+    ack: Any, incident: Incident, update_kwargs: dict[str, Any]
+) -> None:
+    """Show a timeline review checkpoint before moving an incident to Post-mortem.
+
+    Acks the modal submission and posts a review message with the timeline
+    recorded so far, instead of applying the Post-mortem transition
+    immediately. The transition only happens if the human accepts it from
+    that message.
+    """
+    ack()
+    carry_over_payload = build_carry_over_payload(incident, update_kwargs)
+    incident.conversation.send_message_and_save(
+        SlackMessageReviewTimeline(incident, carry_over_payload=carry_over_payload)
+    )
 
 
 def _build_carry_over_from_form(form: Form | None) -> dict[str, Any]:

--- a/tests/test_incidents/test_forms/test_timeline_correction.py
+++ b/tests/test_incidents/test_forms/test_timeline_correction.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.utils import timezone
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.incidents.forms.timeline_correction import TimelineCorrectionForm
+from firefighter.incidents.models.incident_update import IncidentUpdate
+
+if TYPE_CHECKING:
+    from firefighter.incidents.models.incident import Incident
+    from firefighter.incidents.models.user import User
+
+
+@pytest.mark.django_db
+class TestGenerateFieldsDynamically:
+    @staticmethod
+    def test_generates_a_field_per_milestone_and_per_status_reached() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        started_update = IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="started",
+            event_ts=timezone.now() - timezone.timedelta(hours=2),
+            created_by=user,
+        )
+        investigating_update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=timezone.now() - timezone.timedelta(hours=1),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        assert "milestone_started" in form.fields
+        assert form.initial["milestone_started"] == started_update.event_ts
+        assert "milestone_detected" in form.fields
+        assert form.initial["milestone_detected"] == ""
+
+        assert f"status_{investigating_update.id}" in form.fields
+        assert (
+            form.initial[f"status_{investigating_update.id}"]
+            == investigating_update.event_ts
+        )
+
+    @staticmethod
+    def test_open_has_no_editable_field() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        # OPEN is anchored to incident.created_at, never a recorded row -
+        # there must be no status field for it.
+        assert not any(
+            name.startswith("status_") and IncidentStatus.OPEN.label in str(field.label)
+            for name, field in form.fields.items()
+        )
+        assert len(form.fields) == 2 + 1  # 2 milestones + 1 status (MITIGATED)
+
+    @staticmethod
+    def test_status_fields_are_required_milestones_are_optional() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        assert form.fields[f"status_{update.id}"].required is True
+        assert form.fields["milestone_started"].required is False
+
+    @staticmethod
+    def test_reopen_exposes_one_field_per_occurrence_numbered() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        base_time = timezone.now()
+        first_mitigating = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATING,
+            event_ts=base_time,
+            created_by=user,
+        )
+        second_mitigating = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=30),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        mitigating_fields = [
+            name for name in form.fields if name.startswith("status_")
+        ]
+        assert mitigating_fields == [
+            f"status_{first_mitigating.id}",
+            f"status_{second_mitigating.id}",
+        ]
+        assert form.fields[f"status_{first_mitigating.id}"].label == "Mitigating (1)"
+        assert form.fields[f"status_{second_mitigating.id}"].label == "Mitigating (2)"
+
+    @staticmethod
+    def test_status_reached_once_keeps_a_bare_label() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        assert form.fields[f"status_{update.id}"].label == "Mitigated"
+
+
+@pytest.mark.django_db
+class TestSave:
+    @staticmethod
+    def test_creates_a_milestone_that_was_never_recorded() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user: User = UserFactory.create()
+        new_time = timezone.now()
+
+        form = TimelineCorrectionForm(
+            data={"milestone_started": new_time.isoformat()},
+            incident=incident,
+            user=user,
+        )
+        assert form.is_valid(), form.errors
+
+        form.save()
+
+        update = IncidentUpdate.objects.get(incident=incident, event_type="started")
+        assert update.event_ts == new_time
+        assert update.created_by == user
+
+    @staticmethod
+    def test_clearing_a_milestone_deletes_it() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user: User = UserFactory.create()
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="started",
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(
+            data={"milestone_started": ""}, incident=incident, user=user
+        )
+        assert form.is_valid(), form.errors
+
+        form.save()
+
+        assert not IncidentUpdate.objects.filter(
+            incident=incident, event_type="started"
+        ).exists()
+
+    @staticmethod
+    def test_edits_the_status_row_in_place_without_creating_a_new_one() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user: User = UserFactory.create()
+        update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+        corrected_time = update.event_ts - timezone.timedelta(hours=1)
+
+        form = TimelineCorrectionForm(
+            data={f"status_{update.id}": corrected_time.isoformat()},
+            incident=incident,
+            user=user,
+        )
+        assert form.is_valid(), form.errors
+
+        form.save()
+
+        assert (
+            IncidentUpdate.objects.filter(
+                incident=incident, _status=IncidentStatus.MITIGATED
+            ).count()
+            == 1
+        )
+        update.refresh_from_db()
+        assert update.event_ts == corrected_time
+
+    @staticmethod
+    def test_requires_a_user() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        form = TimelineCorrectionForm(data={}, incident=incident)
+
+        assert not form.is_valid()

--- a/tests/test_incidents/test_forms/test_timeline_correction.py
+++ b/tests/test_incidents/test_forms/test_timeline_correction.py
@@ -85,17 +85,18 @@ class TestGenerateFieldsDynamically:
         assert form.fields["milestone_started"].required is False
 
     @staticmethod
-    def test_reopen_exposes_one_field_per_occurrence_numbered() -> None:
+    def test_reopen_exposes_one_field_bound_to_the_last_mitigating() -> None:
+        """Mitigating settles on its last occurrence: that is the editable one."""
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
         user = UserFactory.create()
         base_time = timezone.now()
-        first_mitigating = IncidentUpdate.objects.create(
+        IncidentUpdate.objects.create(
             incident=incident,
             _status=IncidentStatus.MITIGATING,
             event_ts=base_time,
             created_by=user,
         )
-        second_mitigating = IncidentUpdate.objects.create(
+        last_mitigating = IncidentUpdate.objects.create(
             incident=incident,
             _status=IncidentStatus.MITIGATING,
             event_ts=base_time + timezone.timedelta(minutes=30),
@@ -104,15 +105,39 @@ class TestGenerateFieldsDynamically:
 
         form = TimelineCorrectionForm(incident=incident, user=user)
 
-        mitigating_fields = [
-            name for name in form.fields if name.startswith("status_")
-        ]
-        assert mitigating_fields == [
-            f"status_{first_mitigating.id}",
-            f"status_{second_mitigating.id}",
-        ]
-        assert form.fields[f"status_{first_mitigating.id}"].label == "Mitigating (1)"
-        assert form.fields[f"status_{second_mitigating.id}"].label == "Mitigating (2)"
+        status_fields = [name for name in form.fields if name.startswith("status_")]
+        assert status_fields == [f"status_{last_mitigating.id}"]
+        field = form.fields[f"status_{last_mitigating.id}"]
+        assert field.label == "Mitigating (last of 2)"
+        assert form.initial[f"status_{last_mitigating.id}"] == last_mitigating.event_ts
+
+    @staticmethod
+    def test_reopen_exposes_the_first_investigating() -> None:
+        """Investigating started at its first occurrence, not at the last cycle."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        base_time = timezone.now()
+        first_investigating = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=30),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        status_fields = [name for name in form.fields if name.startswith("status_")]
+        assert status_fields == [f"status_{first_investigating.id}"]
+        assert (
+            form.fields[f"status_{first_investigating.id}"].label
+            == "Investigating (first of 2)"
+        )
 
     @staticmethod
     def test_status_reached_once_keeps_a_bare_label() -> None:

--- a/tests/test_jira_app/test_incident_key_events_sync.py
+++ b/tests/test_jira_app/test_incident_key_events_sync.py
@@ -54,6 +54,17 @@ class TestIncidentKeyEventsSync:
             created_by=user,
         )
 
+        # Create a key event (incident update) representing the "declared"
+        # event that Incident.objects.declare() creates in production at
+        # incident creation time.
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
+            created_by=user,
+            message="Incident declared",
+        )
+
         # Create a key event (incident update)
         now = timezone.now()
         IncidentUpdate.objects.create(
@@ -85,7 +96,7 @@ class TestIncidentKeyEventsSync:
         # Verify timeline content was generated (contains basic incident info)
         timeline_content = next(iter(call_kwargs["fields"].values()))
         assert "Timeline" in timeline_content
-        assert "Incident created" in timeline_content
+        assert "Key event: Declared" in timeline_content
 
     @staticmethod
     @patch("firefighter.jira_app.signals.incident_key_events_updated.JiraClient")

--- a/tests/test_jira_app/test_postmortem_service.py
+++ b/tests/test_jira_app/test_postmortem_service.py
@@ -70,6 +70,14 @@ class TestJiraPostMortemService:
         # Create status updates
         now = timezone.now()
 
+        # Declaration marker, at the same instant as created_at
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+
         # Status change to INVESTIGATING
         IncidentUpdate.objects.create(
             incident=incident,
@@ -106,7 +114,7 @@ class TestJiraPostMortemService:
         assert "Status changed to: Mitigated" in timeline
 
         # Verify the initial creation event is present
-        assert "Incident created" in timeline
+        assert "Key event: Declared" in timeline
 
     @staticmethod
     def test_generate_issue_fields_sets_due_date() -> None:

--- a/tests/test_jira_app/test_timeline_template.py
+++ b/tests/test_jira_app/test_timeline_template.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
 from django.template.loader import render_to_string
+from django.test import override_settings
 from django.utils import timezone
 
 from firefighter.incidents.enums import IncidentStatus
 from firefighter.incidents.factories import IncidentFactory, UserFactory
 from firefighter.incidents.models.incident_update import IncidentUpdate
+from firefighter.jira_app.service_postmortem import build_timeline_rows
 
 if TYPE_CHECKING:
     from firefighter.incidents.models.incident import Incident
@@ -30,6 +33,14 @@ class TestTimelineTemplate:
         # Create an incident
         incident: Incident = IncidentFactory.create(
             _status=IncidentStatus.POST_MORTEM,
+            created_by=user,
+        )
+
+        # Event 0: declared (key event) - always the first row, at created_at
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
             created_by=user,
         )
 
@@ -73,11 +84,11 @@ class TestTimelineTemplate:
         # Render the timeline template
         timeline_content = render_to_string(
             "jira/postmortem/timeline.txt",
-            {"incident": incident},
+            {"timeline_rows": build_timeline_rows(incident)},
         )
 
         # Verify timeline contains all events
-        assert "Incident created" in timeline_content
+        assert "Key event: Declared" in timeline_content
         assert "Key event: Detected" in timeline_content
         assert "Issue was detected" in timeline_content
         assert "Status changed to: Investigating" in timeline_content
@@ -87,18 +98,18 @@ class TestTimelineTemplate:
 
         # Verify chronological order by checking positions in the timeline
         # The events should appear in this order:
-        # 1. Incident created
+        # 1. declared (key event)
         # 2. detected (key event)
         # 3. INVESTIGATING (status change)
         # 4. started (key event)
         # 5. MITIGATING (status change)
-        created_pos = timeline_content.find("Incident created")
+        declared_pos = timeline_content.find("Key event: Declared")
         detected_pos = timeline_content.find("Key event: Detected")
         investigating_pos = timeline_content.find("Status changed to: Investigating")
         started_pos = timeline_content.find("Key event: Started")
         mitigating_pos = timeline_content.find("Status changed to: Mitigating")
 
-        assert created_pos < detected_pos < investigating_pos < started_pos < mitigating_pos, (
+        assert declared_pos < detected_pos < investigating_pos < started_pos < mitigating_pos, (
             "Events are not in chronological order"
         )
 
@@ -126,10 +137,124 @@ class TestTimelineTemplate:
         # Render the timeline template
         timeline_content = render_to_string(
             "jira/postmortem/timeline.txt",
-            {"incident": incident},
+            {"timeline_rows": build_timeline_rows(incident)},
         )
 
         # Verify the key event appears without a dash for empty message
         assert "Key event: Detected" in timeline_content
         # Should not have " - " when there's no message
         assert "Key event: Detected -" not in timeline_content
+
+    @staticmethod
+    def test_backfilled_milestone_before_created_at_sorts_first() -> None:
+        """A Started/Detected time backfilled to before created_at must lead the timeline.
+
+        Regression test: "Incident created" used to be hardcoded as the first
+        row regardless of actual event_ts, which put backfilled milestones
+        (routinely earlier than when the incident was declared in
+        FireFighter) out of order.
+        """
+        user: User = UserFactory.create()
+        incident: Incident = IncidentFactory.create(
+            _status=IncidentStatus.POST_MORTEM,
+            created_by=user,
+        )
+
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="started",
+            event_ts=incident.created_at - timezone.timedelta(hours=2),
+            created_by=user,
+        )
+
+        timeline_content = render_to_string(
+            "jira/postmortem/timeline.txt",
+            {"timeline_rows": build_timeline_rows(incident)},
+        )
+
+        started_pos = timeline_content.find("Key event: Started")
+        declared_pos = timeline_content.find("Key event: Declared")
+
+        assert started_pos < declared_pos, (
+            "Backfilled 'Started' milestone must appear before 'Declared'"
+        )
+
+    @staticmethod
+    @override_settings(TIME_ZONE="Europe/Paris")
+    def test_times_are_rendered_in_active_timezone_not_mislabeled_utc() -> None:
+        """Regression: template used to hardcode " UTC" while actually rendering
+        the active timezone (TIME_ZONE setting), mismatching the label against
+        the real converted time - e.g. a 09:00 UTC event rendered as "10:00 UTC"
+        (Paris local time) instead of the correct "10:00 CET".
+        """
+        user: User = UserFactory.create()
+        incident: Incident = IncidentFactory.create(
+            _status=IncidentStatus.POST_MORTEM,
+            created_by=user,
+        )
+        incident.created_at = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+        incident.save()
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+
+        timeline_content = render_to_string(
+            "jira/postmortem/timeline.txt",
+            {"timeline_rows": build_timeline_rows(incident)},
+        )
+
+        # Europe/Paris is UTC+1 in January (CET, no DST).
+        assert "2026-01-15 10:00 CET" in timeline_content
+        assert "UTC" not in timeline_content
+
+    @staticmethod
+    def test_reopen_to_open_shows_as_a_status_change() -> None:
+        """A later, genuine reopen to OPEN is a real transition, not the declaration.
+
+        The OPEN row created at declaration time (same `event_ts` as the
+        "declared" key event) is folded into "Key event: Declared" and must
+        not also render as "Status changed to: Open". But an incident can go
+        back to OPEN later - that row has a different `event_ts` and must
+        still show up as its own "Status changed to: Open" line.
+        """
+        user: User = UserFactory.create()
+        incident: Incident = IncidentFactory.create(
+            _status=IncidentStatus.OPEN,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.OPEN,
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="declared",
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+        reopened_at = incident.created_at + timezone.timedelta(days=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.OPEN,
+            event_ts=reopened_at,
+            created_by=user,
+        )
+
+        timeline_content = render_to_string(
+            "jira/postmortem/timeline.txt",
+            {"timeline_rows": build_timeline_rows(incident)},
+        )
+
+        assert timeline_content.count("Status changed to: Open") == 1
+        assert "Key event: Declared" in timeline_content

--- a/tests/test_slack/test_models/test_conversations.py
+++ b/tests/test_slack/test_models/test_conversations.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
+from firefighter.incidents.factories import IncidentFactory
+from firefighter.slack.messages.base import SlackMessageStrategy
 from firefighter.slack.models.conversation import Conversation
+from firefighter.slack.views.modals.review_timeline import SlackMessageReviewTimeline
 from tests.test_slack.conftest import MockWebClient
 
 
@@ -24,3 +29,31 @@ def test_conversations_join(
 
     conversation.conversations_join(client=mock_web_client)
     assert mock_web_client.conversations_join.called
+
+
+@pytest.mark.django_db
+def test_send_message_update_strategy_targets_explicit_message_when_given(
+    conversation: Conversation, mock_web_client: MockWebClient
+) -> None:
+    """`strategy_args={"ts": ...}` must update that exact message directly.
+
+    Without it, the UPDATE strategy looks up "the last message of this
+    ff_type" in the DB - not what's wanted when a caller already knows
+    precisely which message it's resolving (e.g. from a button-click
+    payload), since more than one message of the same type can coexist.
+    """
+    mock_web_client.chat_update = MagicMock(return_value={"ok": True})
+    incident = IncidentFactory.create()
+    message = SlackMessageReviewTimeline(incident, carry_over_payload="{}")
+
+    conversation.send_message_and_save(
+        message,
+        client=mock_web_client,
+        strategy=SlackMessageStrategy.UPDATE,
+        strategy_args={"ts": "1690000000.123456", "channel_id": "C0TARGET"},
+    )
+
+    mock_web_client.chat_update.assert_called_once()
+    _, kwargs = mock_web_client.chat_update.call_args
+    assert kwargs["channel"] == "C0TARGET"
+    assert kwargs["ts"] == "1690000000.123456"

--- a/tests/test_slack/views/modals/test_review_timeline.py
+++ b/tests/test_slack/views/modals/test_review_timeline.py
@@ -1,0 +1,742 @@
+from __future__ import annotations
+
+import datetime
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+from slack_sdk.models.blocks.block_elements import ButtonElement
+from slack_sdk.models.blocks.blocks import ActionsBlock, HeaderBlock, SectionBlock
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.incidents.models.incident_update import IncidentUpdate
+from firefighter.slack.factories import IncidentChannelFactory, SlackUserFactory
+from firefighter.slack.messages.base import SlackMessageStrategy
+from firefighter.slack.views.modals.review_timeline import (
+    ACCEPT_ACTION_ID,
+    REJECT_ACTION_ID,
+    SlackMessageReviewTimeline,
+    SlackMessageTimelineCorrection,
+    TimelineCorrection,
+    TimelineEntry,
+    _resolved_message_strategy_args,
+    build_carry_over_payload,
+    get_incident_timeline,
+    get_status_timeline,
+    handle_review_timeline_accept,
+    handle_review_timeline_reject,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+    from firefighter.incidents.models.incident import Incident
+
+
+@pytest.mark.django_db
+class TestGetStatusTimeline:
+    @staticmethod
+    def test_open_anchors_to_created_at_even_if_declaration_row_differs() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.OPEN)
+        user = UserFactory.create()
+
+        # The declaration's own OPEN row, at the same instant as created_at -
+        # this is the row the anchor represents, so it must not double up.
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.OPEN,
+            event_ts=incident.created_at,
+            created_by=user,
+        )
+
+        timeline = get_status_timeline(incident)
+        assert timeline == [(IncidentStatus.OPEN, incident.created_at)]
+
+    @staticmethod
+    def test_reopen_to_open_shows_as_its_own_later_entry() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.OPEN)
+        user = UserFactory.create()
+        reopened_at = incident.created_at + timezone.timedelta(days=1)
+
+        # A genuine reopen back to OPEN, distinct from the declaration.
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.OPEN,
+            event_ts=reopened_at,
+            created_by=user,
+        )
+
+        timeline = get_status_timeline(incident)
+
+        assert timeline == [
+            (IncidentStatus.OPEN, incident.created_at),
+            (IncidentStatus.OPEN, reopened_at),
+        ]
+
+    @staticmethod
+    def test_reopen_loop_includes_every_occurrence_chronologically() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        base_time = timezone.now()
+
+        # First pass: INVESTIGATING -> MITIGATING -> MITIGATED
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=10),
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=base_time + timezone.timedelta(minutes=20),
+            created_by=user,
+        )
+        # Reopen: back to INVESTIGATING, then MITIGATING, then MITIGATED again.
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=30),
+            created_by=user,
+            message="Reopening: found a regression.",
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=40),
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=base_time + timezone.timedelta(minutes=50),
+            created_by=user,
+        )
+
+        timeline = get_status_timeline(incident)
+        statuses = [status for status, _ in timeline]
+
+        # Every occurrence is kept, in chronological order - including the
+        # full reopen cycle, matching the Jira post-mortem timeline.
+        assert statuses == [
+            IncidentStatus.OPEN,
+            IncidentStatus.INVESTIGATING,
+            IncidentStatus.MITIGATING,
+            IncidentStatus.MITIGATED,
+            IncidentStatus.INVESTIGATING,
+            IncidentStatus.MITIGATING,
+            IncidentStatus.MITIGATED,
+        ]
+
+        event_timestamps = [event_ts for _, event_ts in timeline]
+        assert event_timestamps == [
+            incident.created_at,
+            base_time,
+            base_time + timezone.timedelta(minutes=10),
+            base_time + timezone.timedelta(minutes=20),
+            base_time + timezone.timedelta(minutes=30),
+            base_time + timezone.timedelta(minutes=40),
+            base_time + timezone.timedelta(minutes=50),
+        ]
+
+
+@pytest.mark.django_db
+class TestGetIncidentTimeline:
+    @staticmethod
+    def test_includes_recorded_milestones_before_status_timeline() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        started_at = incident.created_at - timezone.timedelta(hours=2)
+        detected_at = incident.created_at - timezone.timedelta(hours=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="started",
+            event_ts=started_at,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="detected",
+            event_ts=detected_at,
+            created_by=user,
+        )
+
+        timeline = get_incident_timeline(incident)
+
+        assert timeline[0] == TimelineEntry(label="Started", event_ts=started_at)
+        assert timeline[1] == TimelineEntry(label="Detected", event_ts=detected_at)
+        assert timeline[2].label == "Declared"
+        assert timeline[2].event_ts == incident.created_at
+
+    @staticmethod
+    def test_missing_milestones_show_as_not_recorded() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        timeline = get_incident_timeline(incident)
+
+        assert timeline[0] == TimelineEntry(label="Started", event_ts=None)
+        assert timeline[1] == TimelineEntry(label="Detected", event_ts=None)
+
+    @staticmethod
+    def test_milestones_sort_chronologically_among_themselves() -> None:
+        """Detected can legitimately be recorded before Started (e.g. an
+        automated alert fires before the actual start is pinpointed) - the
+        milestone group must reflect that, not the fixed Started-then-Detected
+        declaration order.
+        """
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        detected_at = incident.created_at - timezone.timedelta(hours=2)
+        started_at = incident.created_at - timezone.timedelta(hours=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="started",
+            event_ts=started_at,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="detected",
+            event_ts=detected_at,
+            created_by=user,
+        )
+
+        timeline = get_incident_timeline(incident)
+
+        assert timeline[0] == TimelineEntry(label="Detected", event_ts=detected_at)
+        assert timeline[1] == TimelineEntry(label="Started", event_ts=started_at)
+
+    @staticmethod
+    def test_unrecorded_milestone_sorts_after_a_recorded_one() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        detected_at = incident.created_at - timezone.timedelta(hours=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="detected",
+            event_ts=detected_at,
+            created_by=user,
+        )
+
+        timeline = get_incident_timeline(incident)
+
+        assert timeline[0] == TimelineEntry(label="Detected", event_ts=detected_at)
+        assert timeline[1] == TimelineEntry(label="Started", event_ts=None)
+
+    @staticmethod
+    def test_only_the_first_open_is_labeled_declared() -> None:
+        """A later reopen to OPEN is a real status, not the declaration - it
+        must keep reading "Open", not "Declared" a second time.
+        """
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.OPEN)
+        user = UserFactory.create()
+        reopened_at = incident.created_at + timezone.timedelta(days=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.OPEN,
+            event_ts=reopened_at,
+            created_by=user,
+        )
+
+        timeline = get_incident_timeline(incident)
+        status_entries = timeline[2:]
+
+        assert status_entries == [
+            TimelineEntry(label="Declared", event_ts=incident.created_at),
+            TimelineEntry(label="Open", event_ts=reopened_at),
+        ]
+
+
+@pytest.mark.django_db
+class TestBuildCarryOverPayload:
+    @staticmethod
+    def test_roundtrip_excludes_status_and_stringifies_ids() -> None:
+        incident: Incident = IncidentFactory.build(id=42)
+        update_kwargs = {
+            "status": IncidentStatus.POST_MORTEM,
+            "priority_id": "e12c3836-ea9b-44bf-a3cf-5a715d62395b",
+            "message": "All good.",
+        }
+
+        payload = json.loads(build_carry_over_payload(incident, update_kwargs))
+
+        assert payload["incident_id"] == 42
+        assert payload["priority_id"] == "e12c3836-ea9b-44bf-a3cf-5a715d62395b"
+        assert payload["message"] == "All good."
+        assert "status" not in payload
+
+
+@pytest.mark.django_db
+class TestSlackMessageReviewTimelineBlocks:
+    @staticmethod
+    def test_pending_shows_accept_and_reject_buttons() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(
+            incident, carry_over_payload='{"incident_id": 1}'
+        ).get_blocks()
+
+        actions_blocks = [b for b in blocks if isinstance(b, ActionsBlock)]
+        assert len(actions_blocks) == 1
+        buttons = actions_blocks[0].elements
+        assert all(isinstance(b, ButtonElement) for b in buttons)
+        action_ids = {b.action_id for b in buttons}
+        assert action_ids == {ACCEPT_ACTION_ID, REJECT_ACTION_ID}
+
+    @staticmethod
+    def test_shows_a_stopwatch_header() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(
+            incident, carry_over_payload='{"incident_id": 1}'
+        ).get_blocks()
+
+        headers = [b for b in blocks if isinstance(b, HeaderBlock)]
+        assert len(headers) == 1
+        assert headers[0].text.text == ":stopwatch: Timeline Review"
+
+    @staticmethod
+    def test_pending_shows_not_recorded_for_missing_milestones() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(
+            incident, carry_over_payload='{"incident_id": 1}'
+        ).get_blocks()
+
+        section_texts = [
+            b.text.text for b in blocks if isinstance(b, SectionBlock)
+        ]
+        assert any("*Started*: _Not recorded_" in text for text in section_texts)
+        assert any("*Detected*: _Not recorded_" in text for text in section_texts)
+
+    @staticmethod
+    def test_accepted_shows_confirmation_and_no_buttons() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.POST_MORTEM)
+
+        blocks = SlackMessageReviewTimeline(incident, resolution="accepted").get_blocks()
+
+        assert not any(isinstance(b, ActionsBlock) for b in blocks)
+        section_texts = [
+            b.text.text for b in blocks if isinstance(b, SectionBlock)
+        ]
+        assert any(
+            "Timeline accepted" in text and "Post-mortem" in text
+            for text in section_texts
+        )
+
+    @staticmethod
+    def test_accepted_shows_the_recorded_post_mortem_time() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        post_mortem_at = timezone.now()
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.POST_MORTEM,
+            event_ts=post_mortem_at,
+            created_by=user,
+        )
+
+        blocks = SlackMessageReviewTimeline(incident, resolution="accepted").get_blocks()
+
+        section_texts = [
+            b.text.text for b in blocks if isinstance(b, SectionBlock)
+        ]
+        assert any(
+            text.startswith(f"• *{IncidentStatus.POST_MORTEM.label}*:")
+            and "_Not recorded_" not in text
+            for text in section_texts
+        )
+
+    @staticmethod
+    def test_rejected_shows_the_rejection_notice_and_no_buttons() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(incident, resolution="rejected").get_blocks()
+
+        assert not any(isinstance(b, ActionsBlock) for b in blocks)
+        section_texts = [
+            b.text.text for b in blocks if isinstance(b, SectionBlock)
+        ]
+        assert any(
+            "Timeline not accepted" in text
+            and "Post-mortem transition was cancelled" in text
+            for text in section_texts
+        )
+
+
+@pytest.mark.django_db
+class TestReviewTimelineActions:
+    @staticmethod
+    def test_accept_creates_post_mortem_update_and_updates_message(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        user = UserFactory.create()
+        slack_user = SlackUserFactory.create(user=user)
+
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        payload = json.dumps({"incident_id": incident.id, "message": "Wrapped up."})
+        body = {
+            "user": {"id": slack_user.slack_id},
+            "actions": [{"value": payload}],
+        }
+        ack = MagicMock()
+
+        handle_review_timeline_accept(ack=ack, body=body)
+
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.POST_MORTEM
+        # The POST_MORTEM transition itself fires the pre-existing "next
+        # actions" message via other signal handlers; we only care that our
+        # own review-timeline confirmation message was among the calls.
+        review_calls = [
+            call
+            for call in send_and_save.call_args_list
+            if isinstance(call.args[0], SlackMessageReviewTimeline)
+        ]
+        assert len(review_calls) == 1
+        assert review_calls[0].args[0].resolution == "accepted"
+
+    @staticmethod
+    def test_accept_pushes_confirmed_timeline_to_jira_when_installed(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        slack_user = SlackUserFactory.create()
+        mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+        mocker.patch("django.apps.apps.is_installed", return_value=True)
+        sync_timeline = mocker.patch(
+            "firefighter.jira_app.signals.sync_timeline_to_jira_postmortem"
+        )
+
+        payload = json.dumps({"incident_id": incident.id})
+        body = {"user": {"id": slack_user.slack_id}, "actions": [{"value": payload}]}
+
+        handle_review_timeline_accept(ack=MagicMock(), body=body)
+
+        sync_timeline.assert_called_once_with(incident)
+
+    @staticmethod
+    def test_accept_skips_jira_push_when_app_not_installed(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        slack_user = SlackUserFactory.create()
+        mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+        mocker.patch("django.apps.apps.is_installed", return_value=False)
+        sync_timeline = mocker.patch(
+            "firefighter.jira_app.signals.sync_timeline_to_jira_postmortem"
+        )
+
+        payload = json.dumps({"incident_id": incident.id})
+        body = {"user": {"id": slack_user.slack_id}, "actions": [{"value": payload}]}
+
+        handle_review_timeline_accept(ack=MagicMock(), body=body)
+
+        sync_timeline.assert_not_called()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.POST_MORTEM
+
+    @staticmethod
+    def test_reject_does_not_change_status_and_updates_message(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        payload = json.dumps({"incident_id": incident.id})
+        body = {"actions": [{"value": payload}]}
+        ack = MagicMock()
+
+        handle_review_timeline_reject(ack=ack, body=body)
+
+        ack.assert_called_once_with()
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.MITIGATED
+
+        # Posts the rejection notice, and the correction message (not just a
+        # pointer to a separate form) so the human can immediately correct
+        # times.
+        assert send_and_save.call_count == 2
+        rejection_call, correction_call = send_and_save.call_args_list
+        assert rejection_call.args[0].resolution == "rejected"
+        assert isinstance(correction_call.args[0], SlackMessageTimelineCorrection)
+        # REPLACE, not the class default UPDATE: a new reject cycle should
+        # remove a stale correction message from a previous cycle rather
+        # than editing it in place.
+        assert correction_call.kwargs["strategy"] == SlackMessageStrategy.REPLACE
+
+    @staticmethod
+    def test_accept_targets_the_clicked_message_explicitly(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        slack_user = SlackUserFactory.create()
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        payload = json.dumps({"incident_id": incident.id})
+        body = {
+            "user": {"id": slack_user.slack_id},
+            "actions": [{"value": payload}],
+            "channel": {"id": "C0123456"},
+            "container": {"type": "message", "message_ts": "1690000000.123456"},
+        }
+
+        handle_review_timeline_accept(ack=MagicMock(), body=body)
+
+        review_call = next(
+            call
+            for call in send_and_save.call_args_list
+            if isinstance(call.args[0], SlackMessageReviewTimeline)
+        )
+        assert review_call.kwargs["strategy"] == SlackMessageStrategy.UPDATE
+        assert review_call.kwargs["strategy_args"] == {
+            "ts": "1690000000.123456",
+            "channel_id": "C0123456",
+        }
+
+    @staticmethod
+    def test_reject_targets_the_clicked_message_explicitly(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        payload = json.dumps({"incident_id": incident.id})
+        body = {
+            "actions": [{"value": payload}],
+            "channel": {"id": "C0123456"},
+            "container": {"type": "message", "message_ts": "1690000000.654321"},
+        }
+
+        handle_review_timeline_reject(ack=MagicMock(), body=body)
+
+        rejection_call = send_and_save.call_args_list[0]
+        assert rejection_call.kwargs["strategy"] == SlackMessageStrategy.UPDATE
+        assert rejection_call.kwargs["strategy_args"] == {
+            "ts": "1690000000.654321",
+            "channel_id": "C0123456",
+        }
+
+
+@pytest.mark.django_db
+class TestTimelineCorrection:
+    @staticmethod
+    def test_build_modal_fn_returns_the_form_blocks() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = TimelineCorrection().build_modal_fn(incident=incident)
+
+        assert len(blocks) > 0
+
+    @staticmethod
+    def test_shows_a_stopwatch_header() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = TimelineCorrection().build_modal_fn(incident=incident)
+
+        headers = [b for b in blocks if isinstance(b, HeaderBlock)]
+        assert len(headers) == 1
+        assert headers[0].text.text == ":stopwatch: Correct the timeline"
+
+    @staticmethod
+    def test_shows_a_continue_to_post_mortem_button() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = TimelineCorrection().build_modal_fn(incident=incident)
+
+        actions_blocks = [b for b in blocks if isinstance(b, ActionsBlock)]
+        assert len(actions_blocks) == 1
+        buttons = actions_blocks[0].elements
+        assert len(buttons) == 1
+        assert buttons[0].action_id == ACCEPT_ACTION_ID
+        payload = json.loads(buttons[0].value)
+        assert payload == {"incident_id": incident.id}
+
+    @staticmethod
+    def test_continue_button_triggers_the_post_mortem_transition(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        slack_user = SlackUserFactory.create()
+        mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        blocks = TimelineCorrection().build_modal_fn(incident=incident)
+        actions_blocks = [b for b in blocks if isinstance(b, ActionsBlock)]
+        continue_button = actions_blocks[0].elements[0]
+        body = {
+            "user": {"id": slack_user.slack_id},
+            "actions": [{"value": continue_button.value}],
+        }
+
+        handle_review_timeline_accept(ack=MagicMock(), body=body)
+
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.POST_MORTEM
+
+    @staticmethod
+    def test_handle_modal_fn_saves_corrections_and_reposts_the_correction_message(
+        mocker: MockerFixture,
+    ) -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        user = UserFactory.create()
+        update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=timezone.now(),
+            created_by=user,
+        )
+        corrected_time = update.event_ts - timezone.timedelta(hours=2)
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+        compute_metrics = mocker.patch.object(incident, "compute_metrics")
+
+        field_name = f"status_{update.id}"
+        body = {
+            "type": "block_actions",
+            "state": {
+                "values": {
+                    field_name: {
+                        field_name: {
+                            "type": "datetimepicker",
+                            "selected_date_time": int(corrected_time.timestamp()),
+                        }
+                    }
+                }
+            },
+        }
+
+        TimelineCorrection().handle_modal_fn(
+            ack=MagicMock(), body=body, user=user, incident=incident
+        )
+
+        update.refresh_from_db()
+        assert update.event_ts == datetime.datetime.fromtimestamp(
+            int(corrected_time.timestamp()), tz=timezone.get_current_timezone()
+        )
+        compute_metrics.assert_called_once()
+
+        # Editing a single field must only refresh the correction message
+        # itself - reposting the "rejected" review message here too would
+        # move/repost it in the channel on every single field edit.
+        assert not any(
+            isinstance(call.args[0], SlackMessageReviewTimeline)
+            for call in send_and_save.call_args_list
+        )
+        correction_call = next(
+            call
+            for call in send_and_save.call_args_list
+            if isinstance(call.args[0], SlackMessageTimelineCorrection)
+        )
+        # Uses the class default (UPDATE) - no reason to delete/repost on
+        # every field change, unlike starting a brand new reject cycle (see
+        # handle_review_timeline_reject).
+        assert "strategy" not in correction_call.kwargs
+
+    @staticmethod
+    def test_handle_modal_fn_surfaces_the_validation_error_and_does_not_crash(
+        mocker: MockerFixture,
+    ) -> None:
+        """Clearing a required `status_*` field must not silently revert with
+        no explanation, and `update_with_form()` must not crash on a
+        `self.form` that was never assigned - e.g. a cold instance whose
+        first-ever handled edit happens to be invalid.
+        """
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        IncidentChannelFactory.create(incident=incident)
+        user = UserFactory.create()
+        update = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=incident.created_at + timezone.timedelta(hours=1),
+            created_by=user,
+        )
+        send_and_save = mocker.patch(
+            "firefighter.slack.models.conversation.Conversation.send_message_and_save"
+        )
+
+        field_name = f"status_{update.id}"
+        body = {
+            "type": "block_actions",
+            "state": {
+                "values": {
+                    field_name: {
+                        field_name: {
+                            "type": "datetimepicker",
+                            # No "selected_date_time" - the user cleared a
+                            # required field.
+                        }
+                    }
+                }
+            },
+        }
+        ack = MagicMock()
+
+        TimelineCorrection().handle_modal_fn(
+            ack=ack, body=body, user=user, incident=incident
+        )
+
+        update.refresh_from_db()
+        assert update.event_ts == incident.created_at + timezone.timedelta(hours=1)
+
+        ack.assert_called_once()
+        assert "required" in ack.call_args.kwargs["text"].lower()
+
+        # The message still refreshes - no crash from an unset `self.form`.
+        assert any(
+            isinstance(call.args[0], SlackMessageTimelineCorrection)
+            for call in send_and_save.call_args_list
+        )
+
+
+class TestResolvedMessageStrategyArgs:
+    @staticmethod
+    def test_extracts_ts_and_channel_from_a_real_interaction_payload() -> None:
+        body = {
+            "channel": {"id": "C0123456"},
+            "container": {"type": "message", "message_ts": "1690000000.123456"},
+        }
+
+        assert _resolved_message_strategy_args(body) == {
+            "ts": "1690000000.123456",
+            "channel_id": "C0123456",
+        }
+
+    @staticmethod
+    def test_returns_none_when_fields_are_missing() -> None:
+        assert _resolved_message_strategy_args({"actions": []}) is None

--- a/tests/test_slack/views/modals/test_review_timeline.py
+++ b/tests/test_slack/views/modals/test_review_timeline.py
@@ -17,6 +17,7 @@ from firefighter.slack.factories import IncidentChannelFactory, SlackUserFactory
 from firefighter.slack.messages.base import SlackMessageStrategy
 from firefighter.slack.views.modals.review_timeline import (
     ACCEPT_ACTION_ID,
+    RECHECK_ACTION_ID,
     REJECT_ACTION_ID,
     SlackMessageReviewTimeline,
     SlackMessageTimelineCorrection,
@@ -34,6 +35,27 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from firefighter.incidents.models.incident import Incident
+
+
+def record_consistent_timeline(incident: Incident) -> None:
+    """Record the required milestones in order, so the consistency gate passes.
+
+    Accept is withheld while the timeline has issues, so any test exercising the
+    transition needs `started` and `detected` recorded before the declaration.
+    """
+    user = UserFactory.create()
+    IncidentUpdate.objects.create(
+        incident=incident,
+        event_type="started",
+        event_ts=incident.created_at - timezone.timedelta(hours=2),
+        created_by=user,
+    )
+    IncidentUpdate.objects.create(
+        incident=incident,
+        event_type="detected",
+        event_ts=incident.created_at - timezone.timedelta(hours=1),
+        created_by=user,
+    )
 
 
 @pytest.mark.django_db
@@ -280,6 +302,7 @@ class TestSlackMessageReviewTimelineBlocks:
     @staticmethod
     def test_pending_shows_accept_and_reject_buttons() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
 
         blocks = SlackMessageReviewTimeline(
             incident, carry_over_payload='{"incident_id": 1}'
@@ -293,6 +316,21 @@ class TestSlackMessageReviewTimelineBlocks:
         assert action_ids == {ACCEPT_ACTION_ID, REJECT_ACTION_ID}
 
     @staticmethod
+    def test_pending_withholds_accept_while_the_timeline_has_issues() -> None:
+        """A wrong timeline drives the post-mortem, so Accept is not offered."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(
+            incident, carry_over_payload='{"incident_id": 1}'
+        ).get_blocks()
+
+        actions_blocks = [b for b in blocks if isinstance(b, ActionsBlock)]
+        action_ids = {b.action_id for b in actions_blocks[0].elements}
+        assert action_ids == {REJECT_ACTION_ID}
+        section_texts = [b.text.text for b in blocks if isinstance(b, SectionBlock)]
+        assert any("issue" in text and "before continuing" in text for text in section_texts)
+
+    @staticmethod
     def test_shows_a_stopwatch_header() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
 
@@ -302,7 +340,9 @@ class TestSlackMessageReviewTimelineBlocks:
 
         headers = [b for b in blocks if isinstance(b, HeaderBlock)]
         assert len(headers) == 1
-        assert headers[0].text.text == ":stopwatch: Timeline Review"
+        # The heading carries the day (or the range) and the timezone, so that
+        # rows can show times only - an incident may span several days.
+        assert headers[0].text.text.startswith(":stopwatch: Timeline Review")
 
     @staticmethod
     def test_pending_shows_not_recorded_for_missing_milestones() -> None:
@@ -315,8 +355,8 @@ class TestSlackMessageReviewTimelineBlocks:
         section_texts = [
             b.text.text for b in blocks if isinstance(b, SectionBlock)
         ]
-        assert any("*Started*: _Not recorded_" in text for text in section_texts)
-        assert any("*Detected*: _Not recorded_" in text for text in section_texts)
+        assert any("*Started* _not recorded_" in text for text in section_texts)
+        assert any("*Detected* _not recorded_" in text for text in section_texts)
 
     @staticmethod
     def test_accepted_shows_confirmation_and_no_buttons() -> None:
@@ -336,6 +376,7 @@ class TestSlackMessageReviewTimelineBlocks:
     @staticmethod
     def test_accepted_shows_the_recorded_post_mortem_time() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         user = UserFactory.create()
         post_mortem_at = timezone.now()
         IncidentUpdate.objects.create(
@@ -351,8 +392,8 @@ class TestSlackMessageReviewTimelineBlocks:
             b.text.text for b in blocks if isinstance(b, SectionBlock)
         ]
         assert any(
-            text.startswith(f"• *{IncidentStatus.POST_MORTEM.label}*:")
-            and "_Not recorded_" not in text
+            f"*{IncidentStatus.POST_MORTEM.label}*" in text
+            and "_not recorded_" not in text
             for text in section_texts
         )
 
@@ -380,6 +421,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         user = UserFactory.create()
         slack_user = SlackUserFactory.create(user=user)
@@ -416,6 +458,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(
@@ -438,6 +481,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(
@@ -495,6 +539,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         send_and_save = mocker.patch(
@@ -579,7 +624,7 @@ class TestTimelineCorrection:
         assert len(actions_blocks) == 1
         buttons = actions_blocks[0].elements
         assert len(buttons) == 1
-        assert buttons[0].action_id == ACCEPT_ACTION_ID
+        assert buttons[0].action_id == RECHECK_ACTION_ID
         payload = json.loads(buttons[0].value)
         assert payload == {"incident_id": incident.id}
 
@@ -588,6 +633,7 @@ class TestTimelineCorrection:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(

--- a/tests/test_slack/views/modals/test_update_status.py
+++ b/tests/test_slack/views/modals/test_update_status.py
@@ -366,6 +366,123 @@ class TestUpdateStatusModal:
         trigger_incident_workflow.assert_not_called()
 
     @staticmethod
+    def test_post_mortem_shows_timeline_review_instead_of_transitioning(
+        mocker: MockerFixture, priority_factory, environment_factory, settings
+    ) -> None:
+        """Test that moving to POST_MORTEM shows a timeline review checkpoint.
+
+        The transition itself must not be applied directly from the modal
+        submission - it's deferred to the Accept action on the review message.
+
+        POST_MORTEM is only a reachable status choice when the incident's
+        priority requires a postmortem and its environment is PRD (see
+        `UpdateStatusForm._set_status_choices`), hence the explicit P1/PRD setup.
+        The checkpoint itself is additionally gated on `incident.needs_postmortem`,
+        which also requires a postmortem system to be enabled - set explicitly
+        here so the test doesn't depend on ambient ENABLE_JIRA_POSTMORTEM/
+        ENABLE_CONFLUENCE settings (e.g. from a local .env vs CI).
+        """
+        settings.ENABLE_JIRA_POSTMORTEM = True
+        p1_priority = priority_factory(value=1, name="P1", needs_postmortem=True)
+        prd_environment = environment_factory(value="PRD", name="Production")
+        incident = IncidentFactory.build(
+            _status=IncidentStatus.MITIGATED,
+            priority=p1_priority,
+            environment=prd_environment,
+        )
+
+        modal = UpdateStatusModal()
+        mock_show_timeline_review = mocker.patch(
+            "firefighter.slack.views.modals.update_status.show_timeline_review"
+        )
+        trigger_incident_workflow = mocker.patch.object(
+            modal, "_trigger_incident_workflow"
+        )
+
+        ack = MagicMock()
+        user = UserFactory.build()
+        user.save()
+
+        submission_copy = dict(valid_submission)
+        submission_copy["view"]["state"]["values"]["status"]["status"][
+            "selected_option"
+        ] = {
+            "text": {"type": "plain_text", "text": "Post-mortem", "emoji": True},
+            "value": "50",
+        }
+        submission_copy["view"]["private_metadata"] = str(incident.id)
+
+        modal.handle_modal_fn(
+            ack=ack, body=submission_copy, incident=incident, user=user
+        )
+
+        mock_show_timeline_review.assert_called_once()
+        call_args = mock_show_timeline_review.call_args.args
+        assert call_args[0] is ack
+        assert call_args[1] is incident
+        assert call_args[2]["status"] == IncidentStatus.POST_MORTEM
+
+        # The transition must not happen directly from the modal submission.
+        trigger_incident_workflow.assert_not_called()
+
+    @staticmethod
+    def test_post_mortem_transitions_directly_when_incident_has_no_postmortem(
+        mocker: MockerFixture, priority_factory, environment_factory
+    ) -> None:
+        """No timeline review checkpoint when the incident has no post-mortem to review.
+
+        POST_MORTEM can still be a reachable form choice for a P1/PRD incident
+        even when no post-mortem system is actually enabled (the form's choice
+        list only checks priority/environment, not `Incident.needs_postmortem`,
+        which also factors in whether Confluence/Jira post-mortem is enabled).
+        In that case the transition should apply immediately, as it did before
+        the review checkpoint existed.
+        """
+        p1_priority = priority_factory(value=1, name="P1", needs_postmortem=True)
+        prd_environment = environment_factory(value="PRD", name="Production")
+        incident = IncidentFactory.build(
+            _status=IncidentStatus.MITIGATED,
+            priority=p1_priority,
+            environment=prd_environment,
+        )
+        mocker.patch.object(
+            type(incident),
+            "needs_postmortem",
+            new_callable=PropertyMock,
+            return_value=False,
+        )
+
+        modal = UpdateStatusModal()
+        mock_show_timeline_review = mocker.patch(
+            "firefighter.slack.views.modals.update_status.show_timeline_review"
+        )
+        trigger_incident_workflow = mocker.patch.object(
+            modal, "_trigger_incident_workflow"
+        )
+
+        ack = MagicMock()
+        user = UserFactory.build()
+        user.save()
+
+        submission_copy = dict(valid_submission)
+        submission_copy["view"]["state"]["values"]["status"]["status"][
+            "selected_option"
+        ] = {
+            "text": {"type": "plain_text", "text": "Post-mortem", "emoji": True},
+            "value": "50",
+        }
+        submission_copy["view"]["private_metadata"] = str(incident.id)
+
+        modal.handle_modal_fn(
+            ack=ack, body=submission_copy, incident=incident, user=user
+        )
+
+        mock_show_timeline_review.assert_not_called()
+        ack.assert_called_once_with()
+        trigger_incident_workflow.assert_called_once()
+        assert trigger_incident_workflow.call_args.kwargs["status"] == IncidentStatus.POST_MORTEM
+
+    @staticmethod
     def test_can_close_when_all_conditions_met(
         mocker: MockerFixture, priority_factory, environment_factory
     ) -> None:


### PR DESCRIPTION
## Summary

Adds a timeline review checkpoint before an incident moves to Post-mortem: instead of transitioning immediately, FireFighter posts a review message in the incident channel showing the recorded timeline and asks a human to confirm it.

- **Review message**: Started/Detected milestones (sorted chronologically, "Not recorded" if missing) followed by the full status history, including every reopen cycle - not deduplicated to "latest per status".
- **Accept**: the Post-mortem transition proceeds, and the confirmed timeline is pushed to the incident's Jira post-mortem "Timeline" field. Jira rows are built from a single chronologically-sorted list, fixing prior bugs where a hardcoded "Incident created" row broke ordering against backfilled milestones and where times were mislabeled "UTC" instead of the active timezone.
- **Reject**: a Timeline Correction message appears (same "edit a field, it saves immediately" pattern as Key Events), with one field per milestone and one per status occurrence - numbered ("Mitigating (1)", "Mitigating (2)") when a status recurs from a reopen. Editing re-syncs the Jira timeline and recomputes incident metrics live.
- **Reopen handling**: an incident can legitimately go back to OPEN. Only the declaration's Open is relabeled "Declared" (matched by timestamp, on both Slack and Jira); a later genuine reopen still renders as "Open" / "Status changed to: Open".
- Fixes a latent bug shared by the message-based Slack forms (Timeline Correction, Key Events): an invalid field edit could crash silently on a cold worker or repost stale data instead of surfacing the real validation error - the ephemeral ack now shows the actual message.

## Test plan

- [x] `pdm run pytest` on the affected suites (`test_review_timeline.py`, `test_timeline_correction.py`, `test_jira_app/`, `test_update_key_events.py`) - all green
- [x] `pdm run lint-ruff` / `pdm run lint-mypy` - clean
- [x] Manually exercised end-to-end against a local dev server + ngrok + Slack: incident creation, Jira RAID + post-mortem ticket creation, Update Status → Post-mortem review/accept/reject, timeline correction, and a reopen-to-Open cycle