### PR TITLE
feat(slack): flag timeline inconsistencies and gate the Post-mortem transition

### DIFF
--- a/src/firefighter/incidents/forms/timeline_correction.py
+++ b/src/firefighter/incidents/forms/timeline_correction.py
@@ -23,6 +23,18 @@ _MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
 )
 
 
+# Which occurrence of a status is the definitive one when a reopen makes it
+# repeat: investigation *started* at its first occurrence, while the mitigation
+# that actually held is the last one. Shared with the Slack review message so
+# both surfaces show and edit the same timestamp.
+DEFINITIVE_OCCURRENCE: dict[IncidentStatus, str] = {
+    IncidentStatus.INVESTIGATING: "first",
+    IncidentStatus.MITIGATING: "last",
+    IncidentStatus.MITIGATED: "last",
+}
+_DEFAULT_OCCURRENCE = "last"
+
+
 class TimelineCorrectionForm(forms.Form):
     """Edit in place the timeline shown in the Post-mortem review checkpoint.
 
@@ -62,7 +74,12 @@ class TimelineCorrectionForm(forms.Form):
                 event_type__in=[
                     event_type for event_type, _ in _MILESTONE_EVENT_TYPES
                 ]
-            ).values_list("event_type", "event_ts")
+            )
+            # Explicit ordering: without it Meta.ordering ("-event_ts") applies and
+            # dict() would keep the OLDEST row per type, while the review message
+            # keeps the newest - the two surfaces would disagree on the same field.
+            .order_by("event_ts")
+            .values_list("event_type", "event_ts")
         )
         for event_type, label in _MILESTONE_EVENT_TYPES:
             field_name = f"milestone_{event_type}"
@@ -79,9 +96,14 @@ class TimelineCorrectionForm(forms.Form):
             if field_name not in self.initial:
                 self.initial[field_name] = milestone_updates.get(event_type) or ""
 
-        for status, occurrence, total, update in self._status_updates_with_occurrence():
+        for status, total, update in self._editable_status_updates():
             field_name = f"status_{update.id}"
-            label = status.label if total == 1 else f"{status.label} ({occurrence})"
+            which = DEFINITIVE_OCCURRENCE.get(status, _DEFAULT_OCCURRENCE)
+            label = (
+                status.label
+                if total == 1
+                else f"{status.label} ({which} of {total})"
+            )
             self.fields[field_name] = forms.DateTimeField(
                 required=True,
                 label=label,
@@ -90,17 +112,20 @@ class TimelineCorrectionForm(forms.Form):
             if field_name not in self.initial:
                 self.initial[field_name] = update.event_ts
 
-    def _status_updates_with_occurrence(
+    def _editable_status_updates(
         self,
-    ) -> list[tuple[IncidentStatus, int, int, IncidentUpdate]]:
-        """Every non-OPEN status-change row, in chronological order.
+    ) -> list[tuple[IncidentStatus, int, IncidentUpdate]]:
+        """One editable row per non-OPEN status, in chronological order.
 
-        Yields `(status, occurrence_index, occurrence_total, update)` so a
-        status reached more than once (reopen cycles) can be numbered
-        ("Mitigating (1)", "Mitigating (2)") while a status reached only
-        once keeps a bare label. Mirrors `review_timeline.get_status_timeline`
-        - full history, no dedup - minus the OPEN special-case (OPEN, including
-        a later reopen back to OPEN, is never an editable row here).
+        A status reached several times (reopen cycles) yields a single field
+        bound to its *last* occurrence: that is the time the incident actually
+        settled on, the one the post-mortem timeline shows, and the only one
+        worth correcting. Earlier occurrences stay as recorded - they are the
+        history of the failed attempts, not a mistake to fix.
+
+        Returns `(status, occurrence_count, update)`; the count is surfaced in
+        the label ("Mitigated (last of 4)") rather than as one numbered field
+        per cycle. OPEN is never editable here, including a later reopen to OPEN.
         """
         updates = list(
             self.incident.incidentupdate_set.filter(_status__isnull=False)
@@ -108,19 +133,22 @@ class TimelineCorrectionForm(forms.Form):
             .order_by("event_ts")
         )
         totals: dict[IncidentStatus, int] = {}
-        for update in updates:
-            if update.status is not None:
-                totals[update.status] = totals.get(update.status, 0) + 1
-
-        seen: dict[IncidentStatus, int] = {}
-        result: list[tuple[IncidentStatus, int, int, IncidentUpdate]] = []
+        chosen: dict[IncidentStatus, IncidentUpdate] = {}
         for update in updates:
             status = update.status
             if status is None:
                 continue
-            seen[status] = seen.get(status, 0) + 1
-            result.append((status, seen[status], totals[status], update))
-        return result
+            totals[status] = totals.get(status, 0) + 1
+            which = DEFINITIVE_OCCURRENCE.get(status, _DEFAULT_OCCURRENCE)
+            if which == "last" or status not in chosen:
+                chosen[status] = update
+
+        return [
+            (status, totals[status], update)
+            for status, update in sorted(
+                chosen.items(), key=lambda item: item[1].event_ts
+            )
+        ]
 
     def clean(self) -> dict[str, Any] | None:
         if self.user is None:

--- a/src/firefighter/slack/views/modals/review_timeline.py
+++ b/src/firefighter/slack/views/modals/review_timeline.py
@@ -18,13 +18,17 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from django.utils.timezone import localtime
-from slack_sdk.models.blocks import Block, HeaderBlock, SectionBlock
+from django.utils.timezone import localtime, now
+from slack_sdk.models.blocks import Block, ContextBlock, HeaderBlock, SectionBlock
+from slack_sdk.models.blocks.basic_components import MarkdownTextObject
 from slack_sdk.models.blocks.block_elements import ButtonElement
 from slack_sdk.models.blocks.blocks import ActionsBlock
 
 from firefighter.incidents.enums import IncidentStatus
-from firefighter.incidents.forms.timeline_correction import TimelineCorrectionForm
+from firefighter.incidents.forms.timeline_correction import (
+    DEFINITIVE_OCCURRENCE,
+    TimelineCorrectionForm,
+)
 from firefighter.incidents.models.incident import Incident
 from firefighter.incidents.signals import incident_key_events_updated
 from firefighter.slack.messages.base import SlackMessageStrategy, SlackMessageSurface
@@ -46,6 +50,7 @@ app = SlackApp()
 
 ACCEPT_ACTION_ID = "review_timeline_accept"
 REJECT_ACTION_ID = "review_timeline_reject"
+RECHECK_ACTION_ID = "review_timeline_recheck"
 
 # Fields carried over from the Update Status submission so they aren't lost
 # while the human reviews the timeline (mirrors utils._build_carry_over_from_form).
@@ -123,6 +128,30 @@ class TimelineEntry(NamedTuple):
 # status timeline - both are collected via the Key Events form (see
 # fixtures/incidents/milestone_type.json) but aren't guaranteed to be filled
 # in, since that form is user-editable and can be skipped.
+# The expected chronological order of an incident, spanning both milestones and
+# status transitions. This interleaving lives nowhere else: MilestoneType has no
+# `order` field and IncidentStatus only orders the statuses among themselves.
+# Single source of truth for the displayed legend and the consistency checks.
+# label, emoji, source key, and which occurrence to keep when a status repeats
+# after a reopen: investigation *started* at its first occurrence, while the
+# mitigation that actually held is the last one - and that is the one the
+# post-mortem timeline must show.
+# label, emoji, source, and whether a missing time is an error. Only the
+# milestones are mandatory (MilestoneType.required): a status that never
+# happened - an incident going straight from Declared to Mitigated, say - is
+# not a mistake and must not be reported as one.
+_EXPECTED_STEPS: tuple[tuple[str, str, str | IncidentStatus, bool], ...] = (
+    ("Started", ":firecracker:", "started", True),
+    ("Detected", ":eyes:", "detected", True),
+    ("Declared", ":loudspeaker:", IncidentStatus.OPEN, False),
+    ("Investigating", ":mag:", IncidentStatus.INVESTIGATING, False),
+    ("Mitigating", ":wrench:", IncidentStatus.MITIGATING, False),
+    ("Mitigated", ":white_check_mark:", IncidentStatus.MITIGATED, False),
+    ("Post-mortem", ":memo:", IncidentStatus.POST_MORTEM, False),
+)
+
+_EXPECTED_ORDER: tuple[str, ...] = tuple(label for label, *_ in _EXPECTED_STEPS)
+
 _MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
     ("started", "Started"),
     ("detected", "Detected"),
@@ -170,6 +199,103 @@ def get_incident_timeline(incident: Incident) -> list[TimelineEntry]:
     return [*milestones, *status_entries]
 
 
+class TimelineIssue(NamedTuple):
+    label: str
+    message: str
+
+
+def _format_delta(delta: datetime.timedelta) -> str:
+    seconds = int(abs(delta).total_seconds())
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    parts = [
+        f"{value}{unit}"
+        for value, unit in ((days, "d"), (hours, "h"), (minutes, "m"), (seconds, "s"))
+        if value
+    ]
+    return " ".join(parts[:2]) if parts else "0s"
+
+
+class TimelineStep(NamedTuple):
+    label: str
+    emoji: str
+    event_ts: datetime.datetime | None
+    occurrences: int
+    required: bool
+
+
+def get_canonical_steps(incident: Incident) -> list[TimelineStep]:
+    """One step per `_EXPECTED_STEPS` entry, collapsing reopen cycles.
+
+    A reopened incident goes through Investigating/Mitigating/Mitigated more than
+    once. Listing every occurrence makes the sequence impossible to check against
+    the expected order and buries the definitive times, so each step keeps a
+    single timestamp and carries its occurrence count instead.
+    """
+    milestone_updates = dict(
+        incident.incidentupdate_set.filter(
+            event_type__in=[event_type for event_type, _ in _MILESTONE_EVENT_TYPES]
+        )
+        .order_by("event_ts")
+        .values_list("event_type", "event_ts")
+    )
+    status_occurrences: dict[IncidentStatus, list[datetime.datetime]] = {}
+    for status, event_ts in get_status_timeline(incident):
+        status_occurrences.setdefault(status, []).append(event_ts)
+
+    steps: list[TimelineStep] = []
+    for label, emoji, source, required in _EXPECTED_STEPS:
+        step_ts: datetime.datetime | None
+        if isinstance(source, str):
+            step_ts = milestone_updates.get(source)
+            count = 1 if step_ts is not None else 0
+        else:
+            stamps = sorted(status_occurrences.get(source) or [])
+            count = len(stamps)
+            which = DEFINITIVE_OCCURRENCE.get(source, "last")
+            step_ts = (stamps[-1] if which == "last" else stamps[0]) if stamps else None
+        steps.append(TimelineStep(label, emoji, step_ts, count, required))
+    return steps
+
+
+def find_timeline_issues(steps: list[TimelineStep]) -> list[TimelineIssue]:
+    """Checks the recorded steps against the expected chronology.
+
+    Reports steps that break the order, required steps with no recorded time,
+    and times in the future - the three ways a hand-typed timeline goes wrong.
+    """
+    issues: list[TimelineIssue] = []
+    right_now = now()
+    previous: tuple[str, datetime.datetime] | None = None
+    for step in steps:
+        label = step.label
+        event_ts = step.event_ts
+        if event_ts is None:
+            if step.required:
+                issues.append(
+                    TimelineIssue(
+                        label, f"*{label}* is required and has no recorded time"
+                    )
+                )
+            continue
+        if event_ts > right_now:
+            issues.append(
+                TimelineIssue(label, f"*{label}* is in the future")
+            )
+        if previous is not None and event_ts < previous[1]:
+            issues.append(
+                TimelineIssue(
+                    label,
+                    f"*{label}* ({localtime(event_ts).strftime('%H:%M:%S')}) is "
+                    f"{_format_delta(previous[1] - event_ts)} before *{previous[0]}* "
+                    f"({localtime(previous[1]).strftime('%H:%M:%S')})",
+                )
+            )
+        previous = (label, event_ts)
+    return issues
+
+
 class SlackMessageReviewTimeline(SlackMessageSurface):
     id = "ff_incident_timeline_review"
     # Each new pending review posts fresh and removes the previous review
@@ -197,16 +323,78 @@ class SlackMessageReviewTimeline(SlackMessageSurface):
         return f"Timeline review before Post-mortem for {self.incident}."
 
     def get_blocks(self) -> list[Block]:
-        blocks: list[Block] = [
-            HeaderBlock(text=":stopwatch: Timeline Review"),
-        ]
-        for entry in get_incident_timeline(self.incident):
-            value = (
-                localtime(entry.event_ts).strftime("%Y-%m-%d %H:%M:%S %Z")
-                if entry.event_ts is not None
-                else "_Not recorded_"
+        steps = get_canonical_steps(self.incident)
+        issues = find_timeline_issues(steps)
+        flagged = {issue.label for issue in issues}
+
+        recorded = sorted(
+            localtime(step.event_ts) for step in steps if step.event_ts is not None
+        )
+        dates = {ts.date() for ts in recorded}
+        # Incidents can span several days, so the date is never dropped: a single
+        # day goes in the heading and the rows carry times only, otherwise the
+        # heading carries the range and every row carries its own day.
+        single_day = len(dates) == 1
+        heading = ":stopwatch: Timeline Review"
+        if recorded:
+            first, last = recorded[0].date(), recorded[-1].date()
+            if single_day:
+                span = first.strftime("%d %b %Y")
+            elif (first.year, first.month) == (last.year, last.month):
+                span = f"{first.day} → {last.strftime('%d %b %Y')}"
+            elif first.year == last.year:
+                span = f"{first.strftime('%d %b')} → {last.strftime('%d %b %Y')}"
+            else:
+                span = f"{first.strftime('%d %b %Y')} → {last.strftime('%d %b %Y')}"
+            heading = f"{heading} — {span} ({recorded[0].strftime('%Z')})"
+
+        blocks: list[Block] = [HeaderBlock(text=heading)]
+
+        # Horizontal chain: reads as a timeline at a glance and wraps on its own
+        # in Slack. Times are minute-precision here to keep the chain short - the
+        # exact seconds are in the issue list below and in the correction form.
+        chain = []
+        for step in steps:
+            if step.event_ts is None and not step.required:
+                continue
+            if step.event_ts is None:
+                stamp = "_not recorded_"
+            else:
+                local = localtime(step.event_ts)
+                stamp = local.strftime("%H:%M" if single_day else "%d/%m %H:%M")
+            marks = " :warning:" if step.label in flagged else ""
+            reopened = f" ↻{step.occurrences - 1}" if step.occurrences > 1 else ""
+            chain.append(f"{step.emoji} *{step.label}* {stamp}{marks}{reopened}")
+        blocks.append(SectionBlock(text="  ➜  ".join(chain)))
+
+        if issues:
+            details = "\n".join(f"> • {issue.message}" for issue in issues)
+            blocks.append(
+                SectionBlock(
+                    text=(
+                        f":warning: *{len(issues)} issue"
+                        f"{'s' if len(issues) > 1 else ''} to fix before "
+                        f"continuing*\n{details}"
+                    )
+                )
             )
-            blocks.append(SectionBlock(text=f"• *{entry.label}*: {value}"))
+        elif self.resolution is None:
+            blocks.append(
+                SectionBlock(
+                    text=":white_check_mark: *No inconsistency detected* — order and recorded times are consistent."
+                )
+            )
+
+        blocks.append(
+            ContextBlock(
+                elements=[
+                    MarkdownTextObject(
+                        text="Expected order: " + " → ".join(_EXPECTED_ORDER)
+                        + "   ·   ↻ = reopen cycles"
+                    )
+                ]
+            )
+        )
 
         if self.resolution == "accepted":
             blocks.append(
@@ -225,23 +413,28 @@ class SlackMessageReviewTimeline(SlackMessageSurface):
                 )
             )
         else:
-            blocks.append(
-                ActionsBlock(
-                    elements=[
-                        ButtonElement(
-                            text="Looks correct — continue to Post-mortem",
-                            style="primary",
-                            action_id=ACCEPT_ACTION_ID,
-                            value=self.carry_over_payload,
-                        ),
-                        ButtonElement(
-                            text="Not accurate — let me fix it",
-                            action_id=REJECT_ACTION_ID,
-                            value=self.carry_over_payload,
-                        ),
-                    ]
+            # Accept is withheld while the timeline is inconsistent: a wrong
+            # timeline drives the post-mortem and the incident metrics. Slack
+            # cannot disable a button, so it is simply not rendered - the accept
+            # handler re-checks as well, since an older message stays clickable.
+            actions = []
+            if not issues:
+                actions.append(
+                    ButtonElement(
+                        text="Looks correct — continue to Post-mortem",
+                        style="primary",
+                        action_id=ACCEPT_ACTION_ID,
+                        value=self.carry_over_payload,
+                    )
+                )
+            actions.append(
+                ButtonElement(
+                    text="Not accurate — let me fix it",
+                    action_id=REJECT_ACTION_ID,
+                    value=self.carry_over_payload,
                 )
             )
+            blocks.append(ActionsBlock(elements=actions))
         return blocks
 
 
@@ -265,6 +458,25 @@ def _resolved_message_strategy_args(body: dict[str, Any]) -> dict[str, Any] | No
 @app.action(ACCEPT_ACTION_ID)
 def handle_review_timeline_accept(ack: Ack, body: dict[str, Any]) -> None:
     ack()
+    _resolve_timeline_and_transition(body, update_in_place=True)
+
+
+@app.action(RECHECK_ACTION_ID)
+def handle_review_timeline_recheck(ack: Ack, body: dict[str, Any]) -> None:
+    """Re-run the checks from the correction message and transition if clean.
+
+    Saves a round trip through the Update Status modal once the times are fixed.
+    The transition it applies carries the status only: the message and any
+    priority or category change from the original submission cannot be threaded
+    across the correction step, so nothing pretends to carry them.
+    """
+    ack()
+    _resolve_timeline_and_transition(body, update_in_place=False)
+
+
+def _resolve_timeline_and_transition(
+    body: dict[str, Any], *, update_in_place: bool
+) -> None:
     payload = _parse_action_payload(body)
     if payload is None:
         return
@@ -275,15 +487,38 @@ def handle_review_timeline_accept(ack: Ack, body: dict[str, Any]) -> None:
         respond(body, text=":x: Incident not found.")
         return
 
+    # Re-check server-side: the button is not rendered when the timeline is
+    # inconsistent, but an older review message left in the channel stays
+    # clickable, so the gate cannot live in the rendering alone.
+    issues = find_timeline_issues(get_canonical_steps(incident))
+    if issues:
+        respond(
+            body,
+            text=(
+                ":warning: The timeline still has "
+                f"{len(issues)} issue{'s' if len(issues) > 1 else ''} to fix: "
+                + "; ".join(issue.message for issue in issues)
+            ),
+        )
+        return
+
     user = get_user_from_context(body)
+    # Flush the edits made in the correction form now that the reviewer is done:
+    # this refreshes the Key Events form message (it shows the same milestones)
+    # and re-syncs the Jira timeline, once instead of once per keystroke.
+    incident_key_events_updated.send_robust(__name__, incident=incident)
     incident.create_incident_update(
         created_by=user, status=IncidentStatus.POST_MORTEM, **payload
     )
     _push_confirmed_timeline_to_jira(incident)
+    # Accept edits the review message it was clicked from; the re-check button
+    # lives on the correction message, so it posts the outcome as a new message
+    # rather than overwriting a form the reviewer may still be reading.
+    strategy_args = _resolved_message_strategy_args(body) if update_in_place else None
     incident.conversation.send_message_and_save(
         SlackMessageReviewTimeline(incident, resolution="accepted"),
-        strategy=SlackMessageStrategy.UPDATE,
-        strategy_args=_resolved_message_strategy_args(body),
+        strategy=SlackMessageStrategy.UPDATE if update_in_place else SlackMessageStrategy.APPEND,
+        strategy_args=strategy_args,
     )
 
 
@@ -342,19 +577,33 @@ class TimelineCorrection(MessageForm[TimelineCorrectionForm]):
         slack_form: SlackForm[TimelineCorrectionForm] = self.get_form_class()
         slack_form.form = form
         blocks += slack_form.slack_blocks()
+        # Deliberately not an "accept" button: it re-runs the checks and only
+        # transitions if they pass. Its payload is the incident id alone - the
+        # original Update Status submission (its message, any priority or
+        # category change) cannot be threaded across the correction step, and
+        # this way nothing pretends to carry it.
         blocks.append(
             ActionsBlock(
                 elements=[
                     ButtonElement(
-                        text="Looks correct — continue to Post-mortem",
+                        text="Re-check timeline & continue to Post-mortem",
                         style="primary",
-                        action_id=ACCEPT_ACTION_ID,
-                        # Minimal payload (just the incident id), regenerated
-                        # fresh on every render - avoids needing to carry the
-                        # original Update Status submission's payload across
-                        # an indefinite number of field-edit reposts.
+                        action_id=RECHECK_ACTION_ID,
                         value=build_carry_over_payload(form.incident, {}),
                     ),
+                ]
+            )
+        )
+        blocks.append(
+            ContextBlock(
+                elements=[
+                    MarkdownTextObject(
+                        text=(
+                            "Re-checking applies the status change only. To also "
+                            "post an update message, run *Update Status* → "
+                            "*Post-mortem* instead."
+                        )
+                    )
                 ]
             )
         )
@@ -376,17 +625,20 @@ class TimelineCorrection(MessageForm[TimelineCorrectionForm]):
             return
         self.form.save()
 
-        # Same side effects as the Key Events form: refresh the Jira
-        # post-mortem timeline and the incident's computed metrics.
-        incident_key_events_updated.send_robust(__name__, incident=incident)
+        # Metrics are cheap and local, so they stay in sync on every edit.
         incident.compute_metrics()
 
-        # Only the correction message itself needs refreshing here - this
-        # runs on every single field edit (like Key Events), so reposting
-        # the "rejected" review message too would move/repost it on every
-        # keystroke. That message already showed why the review was
-        # rejected; the corrected timeline becomes visible in a fresh review
-        # message the next time Update Status -> Post-mortem is submitted.
+        # `incident_key_events_updated` is deliberately NOT sent here. This
+        # method runs on every single field edit, and the signal fans out to a
+        # Jira round trip plus a refresh of the Key Events form message - which
+        # shows the same started/detected values, so Slack marks it "(edited)"
+        # and resurfaces it on every keystroke. Both are done once the reviewer
+        # is finished, from `_resolve_timeline_and_transition`, which keeps the
+        # two surfaces consistent without the noise (and without ~2 Jira calls
+        # per edited field).
+        #
+        # Only the correction message itself is refreshed here, to echo the
+        # value that was just saved.
         self.update_with_form()
 
     def update_with_form(self) -> None:

--- a/tests/test_incidents/test_forms/test_timeline_correction.py
+++ b/tests/test_incidents/test_forms/test_timeline_correction.py
@@ -85,17 +85,18 @@ class TestGenerateFieldsDynamically:
         assert form.fields["milestone_started"].required is False
 
     @staticmethod
-    def test_reopen_exposes_one_field_per_occurrence_numbered() -> None:
+    def test_reopen_exposes_one_field_bound_to_the_last_mitigating() -> None:
+        """Mitigating settles on its last occurrence: that is the editable one."""
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
         user = UserFactory.create()
         base_time = timezone.now()
-        first_mitigating = IncidentUpdate.objects.create(
+        IncidentUpdate.objects.create(
             incident=incident,
             _status=IncidentStatus.MITIGATING,
             event_ts=base_time,
             created_by=user,
         )
-        second_mitigating = IncidentUpdate.objects.create(
+        last_mitigating = IncidentUpdate.objects.create(
             incident=incident,
             _status=IncidentStatus.MITIGATING,
             event_ts=base_time + timezone.timedelta(minutes=30),
@@ -104,15 +105,39 @@ class TestGenerateFieldsDynamically:
 
         form = TimelineCorrectionForm(incident=incident, user=user)
 
-        mitigating_fields = [
-            name for name in form.fields if name.startswith("status_")
-        ]
-        assert mitigating_fields == [
-            f"status_{first_mitigating.id}",
-            f"status_{second_mitigating.id}",
-        ]
-        assert form.fields[f"status_{first_mitigating.id}"].label == "Mitigating (1)"
-        assert form.fields[f"status_{second_mitigating.id}"].label == "Mitigating (2)"
+        status_fields = [name for name in form.fields if name.startswith("status_")]
+        assert status_fields == [f"status_{last_mitigating.id}"]
+        field = form.fields[f"status_{last_mitigating.id}"]
+        assert field.label == "Mitigating (last of 2)"
+        assert form.initial[f"status_{last_mitigating.id}"] == last_mitigating.event_ts
+
+    @staticmethod
+    def test_reopen_exposes_the_first_investigating() -> None:
+        """Investigating started at its first occurrence, not at the last cycle."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        base_time = timezone.now()
+        first_investigating = IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time,
+            created_by=user,
+        )
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.INVESTIGATING,
+            event_ts=base_time + timezone.timedelta(minutes=30),
+            created_by=user,
+        )
+
+        form = TimelineCorrectionForm(incident=incident, user=user)
+
+        status_fields = [name for name in form.fields if name.startswith("status_")]
+        assert status_fields == [f"status_{first_investigating.id}"]
+        assert (
+            form.fields[f"status_{first_investigating.id}"].label
+            == "Investigating (first of 2)"
+        )
 
     @staticmethod
     def test_status_reached_once_keeps_a_bare_label() -> None:

--- a/tests/test_slack/views/modals/test_review_timeline.py
+++ b/tests/test_slack/views/modals/test_review_timeline.py
@@ -17,6 +17,7 @@ from firefighter.slack.factories import IncidentChannelFactory, SlackUserFactory
 from firefighter.slack.messages.base import SlackMessageStrategy
 from firefighter.slack.views.modals.review_timeline import (
     ACCEPT_ACTION_ID,
+    RECHECK_ACTION_ID,
     REJECT_ACTION_ID,
     SlackMessageReviewTimeline,
     SlackMessageTimelineCorrection,
@@ -34,6 +35,27 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from firefighter.incidents.models.incident import Incident
+
+
+def record_consistent_timeline(incident: Incident) -> None:
+    """Record the required milestones in order, so the consistency gate passes.
+
+    Accept is withheld while the timeline has issues, so any test exercising the
+    transition needs `started` and `detected` recorded before the declaration.
+    """
+    user = UserFactory.create()
+    IncidentUpdate.objects.create(
+        incident=incident,
+        event_type="started",
+        event_ts=incident.created_at - timezone.timedelta(hours=2),
+        created_by=user,
+    )
+    IncidentUpdate.objects.create(
+        incident=incident,
+        event_type="detected",
+        event_ts=incident.created_at - timezone.timedelta(hours=1),
+        created_by=user,
+    )
 
 
 @pytest.mark.django_db
@@ -280,6 +302,7 @@ class TestSlackMessageReviewTimelineBlocks:
     @staticmethod
     def test_pending_shows_accept_and_reject_buttons() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
 
         blocks = SlackMessageReviewTimeline(
             incident, carry_over_payload='{"incident_id": 1}'
@@ -293,6 +316,21 @@ class TestSlackMessageReviewTimelineBlocks:
         assert action_ids == {ACCEPT_ACTION_ID, REJECT_ACTION_ID}
 
     @staticmethod
+    def test_pending_withholds_accept_while_the_timeline_has_issues() -> None:
+        """A wrong timeline drives the post-mortem, so Accept is not offered."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+
+        blocks = SlackMessageReviewTimeline(
+            incident, carry_over_payload='{"incident_id": 1}'
+        ).get_blocks()
+
+        actions_blocks = [b for b in blocks if isinstance(b, ActionsBlock)]
+        action_ids = {b.action_id for b in actions_blocks[0].elements}
+        assert action_ids == {REJECT_ACTION_ID}
+        section_texts = [b.text.text for b in blocks if isinstance(b, SectionBlock)]
+        assert any("issue" in text and "before continuing" in text for text in section_texts)
+
+    @staticmethod
     def test_shows_a_stopwatch_header() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
 
@@ -302,7 +340,9 @@ class TestSlackMessageReviewTimelineBlocks:
 
         headers = [b for b in blocks if isinstance(b, HeaderBlock)]
         assert len(headers) == 1
-        assert headers[0].text.text == ":stopwatch: Timeline Review"
+        # The heading carries the day (or the range) and the timezone, so that
+        # rows can show times only - an incident may span several days.
+        assert headers[0].text.text.startswith(":stopwatch: Timeline Review")
 
     @staticmethod
     def test_pending_shows_not_recorded_for_missing_milestones() -> None:
@@ -315,8 +355,8 @@ class TestSlackMessageReviewTimelineBlocks:
         section_texts = [
             b.text.text for b in blocks if isinstance(b, SectionBlock)
         ]
-        assert any("*Started*: _Not recorded_" in text for text in section_texts)
-        assert any("*Detected*: _Not recorded_" in text for text in section_texts)
+        assert any("*Started* _not recorded_" in text for text in section_texts)
+        assert any("*Detected* _not recorded_" in text for text in section_texts)
 
     @staticmethod
     def test_accepted_shows_confirmation_and_no_buttons() -> None:
@@ -336,6 +376,7 @@ class TestSlackMessageReviewTimelineBlocks:
     @staticmethod
     def test_accepted_shows_the_recorded_post_mortem_time() -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         user = UserFactory.create()
         post_mortem_at = timezone.now()
         IncidentUpdate.objects.create(
@@ -351,8 +392,8 @@ class TestSlackMessageReviewTimelineBlocks:
             b.text.text for b in blocks if isinstance(b, SectionBlock)
         ]
         assert any(
-            text.startswith(f"• *{IncidentStatus.POST_MORTEM.label}*:")
-            and "_Not recorded_" not in text
+            f"*{IncidentStatus.POST_MORTEM.label}*" in text
+            and "_not recorded_" not in text
             for text in section_texts
         )
 
@@ -380,6 +421,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         user = UserFactory.create()
         slack_user = SlackUserFactory.create(user=user)
@@ -416,6 +458,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(
@@ -438,6 +481,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(
@@ -495,6 +539,7 @@ class TestReviewTimelineActions:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         send_and_save = mocker.patch(
@@ -579,7 +624,7 @@ class TestTimelineCorrection:
         assert len(actions_blocks) == 1
         buttons = actions_blocks[0].elements
         assert len(buttons) == 1
-        assert buttons[0].action_id == ACCEPT_ACTION_ID
+        assert buttons[0].action_id == RECHECK_ACTION_ID
         payload = json.loads(buttons[0].value)
         assert payload == {"incident_id": incident.id}
 
@@ -588,6 +633,7 @@ class TestTimelineCorrection:
         mocker: MockerFixture,
     ) -> None:
         incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        record_consistent_timeline(incident)
         IncidentChannelFactory.create(incident=incident)
         slack_user = SlackUserFactory.create()
         mocker.patch(


### PR DESCRIPTION
Builds on #336 — targets `feat/timeline-review-before-postmortem`, not `main`.

The review message currently lists the recorded times and leaves the reviewer to spot mistakes unaided, which is the one thing it exists for. This makes it state the expected order, check the timeline against it, and name what is wrong.

## What changes

**Consistency checks.** Three, all derived from one canonical sequence (`_EXPECTED_STEPS`): a step recorded before the one preceding it, a required milestone with no recorded time, and a time in the future. A status that simply never happened is not reported — only the milestones are mandatory.

**Accept is gated.** A wrong timeline drives the post-mortem and the incident metrics, so Accept is not rendered while any check fires. The handler re-checks server-side too: an older review message left in the channel stays clickable.

**Reopen cycles collapse.** Each status keeps one entry at its definitive occurrence — first for Investigating (investigation *started* then), last for Mitigating/Mitigated (the attempt that held) — with the cycle count shown as `↻n`. The correction form follows the same rule, so a 4-cycle incident goes from 12 numbered fields to 5. The rule lives in `DEFINITIVE_OCCURRENCE` in the incidents layer and is shared by both surfaces; they used to disagree on the same field.

**Rendering.** Horizontal chain, one emoji per step, times only — the day (or the range, for an incident spanning several days) sits in the heading. One section block instead of one per row, which also keeps a long timeline clear of Slack's 50-block limit.

**The correction message loses Accept, gains Re-check.** Accepting from there carried `build_carry_over_payload(incident, {})` — an empty payload — silently dropping the message and any priority change from the original Update Status submission. Re-check re-runs the checks, applies the status change only, and says so.

**Side effects fire once.** The Jira re-sync and the Key Events refresh moved off the per-keystroke path to the moment the review is resolved. The Key Events message shows the same `started`/`detected` values, so it was being re-edited — and resurfaced by Slack — on every field edit, along with two Jira round trips per edited field.

## Two fixes to pre-existing behaviour

- Milestone prefill in the correction form had no `order_by`, so `Meta.ordering` (`-event_ts`) applied and `dict()` kept the **oldest** row per type while the review message kept the newest.
- `Post-mortem` is now shown in the chain once it has a time, restoring what the pre-existing test pinned.

## Product decisions worth confirming

- **Blocking is deliberate**, and it makes the Key Events form a hard prerequisite for leaving Mitigated: `started` and `detected` are `required=True`. This aligns the Post-mortem gate with the closure gate, which already refuses to close without them. `closure_reason` remains the bypass.
- **`Recovered` is intentionally absent.** It is `required=True` but has no input anywhere, so flagging it would have created a dead end under a blocking gate.
- **Two broadcasts remain coupled to each other** in the review path; out of scope here.

## Verification

- `test_review_timeline.py` 30 passed, `test_timeline_correction.py` 10 passed
- Full suite: 19 failures, byte-identical to the set already failing on `main` (`staticfiles manifest`, `test_urls`) — no regression
- `lint-ruff` and `lint-mypy` clean
- Exercised end to end against a local server + ngrok on the test Slack workspace, including a 4-cycle reopen
