### PR TITLE
fix(slack): isolate broadcast publications from incident channel ones

### DIFF
--- a/src/firefighter/jira_app/signals/postmortem_created.py
+++ b/src/firefighter/jira_app/signals/postmortem_created.py
@@ -211,7 +211,16 @@ def postmortem_created_handler(
             f"confluence={confluence_pm is not None}, jira={jira_pm is not None}"
         )
         postmortem_created.send_robust(sender=__name__, incident=incident)
-        _publish_postmortem_announcement(incident)
+        # Announcing to #critical-incidents is a broadcast: it must never prevent
+        # the reminder below. Isolated in place rather than moved to its own
+        # receiver, because postmortem_created is also emitted by
+        # firefighter.confluence.models and a receiver would risk announcing twice.
+        try:
+            _publish_postmortem_announcement(incident)
+        except Exception:
+            logger.exception(
+                f"Post-mortem announcement failed, continuing for incident #{incident.id}"
+            )
 
     # Publish reminder
     publish_postmortem_reminder(incident)

--- a/src/firefighter/slack/signals/incident_updated.py
+++ b/src/firefighter/slack/signals/incident_updated.py
@@ -31,22 +31,25 @@ logger = logging.getLogger(__name__)
 
 
 @receiver(signal=incident_updated, sender="update_status")
-def incident_updated_update_status_handler(
+def incident_updated_channel_maintenance_handler(
     sender: Any,
     incident: Incident,
     incident_update: IncidentUpdate,
     updated_fields: list[str],
     **kwargs: Any,
 ) -> None:
+    """Keep the incident channel name and topic in sync.
+
+    Registered on its own so a Slack failure here is contained by
+    Signal.send_robust() instead of suppressing the publications below.
+    """
     # Skip Slack operations for incidents without channels (e.g., P4-P5)
     if not hasattr(incident, "conversation"):
         logger.debug(f"Skipping Slack channel update for incident {incident.id} (no conversation)")
         return
 
-    # Update Slack channel if needed
     incident.conversation.rename_if_needed()
 
-    # Update topic if needed
     if (
         "priority_id" in updated_fields
         or "incident_category_id" in updated_fields
@@ -54,7 +57,37 @@ def incident_updated_update_status_handler(
     ):
         incident.conversation.set_incident_channel_topic()
 
-    publish_status_update(
+
+@receiver(signal=incident_updated, sender="update_status")
+def incident_updated_update_status_handler(
+    sender: Any,
+    incident: Incident,
+    incident_update: IncidentUpdate,
+    updated_fields: list[str],
+    **kwargs: Any,
+) -> None:
+    """Publish the status update and the Key Events form in the incident channel."""
+    publish_incident_channel_update(
+        incident=incident,
+        incident_update=incident_update,
+        status_changed=bool("_status" in updated_fields),
+    )
+
+
+@receiver(signal=incident_updated, sender="update_status")
+def incident_updated_broadcast_handler(
+    sender: Any,
+    incident: Incident,
+    incident_update: IncidentUpdate,
+    updated_fields: list[str],
+    **kwargs: Any,
+) -> None:
+    """Broadcast the update to the org-wide channels.
+
+    Kept out of the incident-channel handler on purpose: broadcast channels are
+    independent, and losing one must never suppress what responders rely on.
+    """
+    publish_broadcasts(
         incident=incident,
         incident_update=incident_update,
         status_changed=bool("_status" in updated_fields),
@@ -208,14 +241,13 @@ def incident_key_events_updated_handler(
     incident.conversation.send_message_and_save(SlackMessageKeyEvents(incident))
 
 
-def publish_status_update(
+def publish_incident_channel_update(
     incident: Incident,
     incident_update: IncidentUpdate,
     *,
     status_changed: bool = False,
-    old_priority: Priority | None = None,
 ) -> None:
-    """Publishes an update to the incident status."""
+    """Publishes the status update and the Key Events form in the incident channel."""
     # Skip Slack operations for incidents without channels (e.g., P4-P5)
     if not hasattr(incident, "conversation"):
         logger.debug(f"Skipping status update publication for incident {incident.id} (no conversation)")
@@ -227,17 +259,6 @@ def publish_status_update(
         in_channel=True,
     )
     incident.conversation.send_message_and_save(message)
-
-    # Post to #tech-incidents
-    if should_publish_in_general_channel(
-        incident=incident, incident_update=incident_update, old_priority=old_priority
-    ):
-        publish_update_in_general_channel(
-            incident=incident,
-            incident_update=incident_update,
-            status_changed=status_changed,
-            old_priority=old_priority,
-        )
 
     if (
         incident.ask_for_milestones
@@ -251,6 +272,26 @@ def publish_status_update(
 
         incident.conversation.send_message_and_save(
             SlackMessageKeyEvents(incident=incident)
+        )
+
+
+def publish_broadcasts(
+    incident: Incident,
+    incident_update: IncidentUpdate,
+    *,
+    status_changed: bool = False,
+    old_priority: Priority | None = None,
+) -> None:
+    """Publishes the update to the org-wide broadcast channels."""
+    # Post to #tech-incidents
+    if should_publish_in_general_channel(
+        incident=incident, incident_update=incident_update, old_priority=old_priority
+    ):
+        publish_update_in_general_channel(
+            incident=incident,
+            incident_update=incident_update,
+            status_changed=status_changed,
+            old_priority=old_priority,
         )
 
     if should_publish_in_it_deploy_channel(incident=incident):

--- a/tests/test_jira_app/test_postmortem_announcement_isolation.py
+++ b/tests/test_jira_app/test_postmortem_announcement_isolation.py
@@ -1,0 +1,61 @@
+"""Tests that a failing post-mortem announcement does not drop the reminder."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.test import override_settings
+from slack_sdk.errors import SlackApiError
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.incidents.models import Environment, Priority
+from firefighter.slack.factories import IncidentChannelFactory
+from firefighter.slack.models.conversation import Conversation
+from firefighter.slack.models.incident_channel import IncidentChannel
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+HANDLER = "firefighter.jira_app.signals.postmortem_created"
+REMINDER = "firefighter.slack.tasks.reminder_postmortem.publish_postmortem_reminder"
+
+
+@pytest.mark.django_db
+class TestPostMortemAnnouncementIsolation:
+    """The #critical-incidents announcement must not abort the rest of the handler."""
+
+    @staticmethod
+    @override_settings(ENABLE_JIRA_POSTMORTEM=True)
+    def test_reminder_still_published_when_announcement_fails(
+        mocker: MockerFixture,
+    ) -> None:
+        """A dead broadcast channel must not swallow the post-mortem reminder."""
+        user = UserFactory.build()
+        user.save()
+        incident = IncidentFactory.build(
+            priority=Priority.objects.get(name="P1"),
+            environment=Environment.objects.get(value="PRD"),
+            created_by=user,
+            private=False,
+            _status=IncidentStatus.MITIGATING,
+        )
+        incident.save()
+        IncidentChannelFactory.build(incident=incident).save()
+
+        mocker.patch.object(IncidentChannel, "rename_if_needed")
+        mocker.patch.object(IncidentChannel, "set_incident_channel_topic")
+        mocker.patch.object(Conversation, "send_message_and_save")
+        mocker.patch(f"{HANDLER}._create_jira_postmortem", return_value=object())
+        mocker.patch(
+            f"{HANDLER}._publish_postmortem_announcement",
+            side_effect=SlackApiError(
+                "channel_not_found", response={"error": "channel_not_found"}
+            ),
+        )
+        mock_reminder = mocker.patch(REMINDER)
+
+        incident.create_incident_update(created_by=user, status=IncidentStatus.MITIGATED)
+
+        mock_reminder.assert_called_once()

--- a/tests/test_slack/test_signals_broadcast_isolation.py
+++ b/tests/test_slack/test_signals_broadcast_isolation.py
@@ -1,0 +1,119 @@
+"""Tests that broadcast publications cannot suppress incident-channel publications."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from firefighter.incidents.enums import IncidentStatus
+from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.incidents.models import Environment, Priority
+from firefighter.slack.factories import IncidentChannelFactory
+from firefighter.slack.models.conversation import Conversation
+from firefighter.slack.models.incident_channel import IncidentChannel
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+BROADCAST_TARGET = (
+    "firefighter.slack.signals.incident_updated.publish_update_in_general_channel"
+)
+INCIDENT_CHANNEL_TARGET = (
+    "firefighter.slack.signals.incident_updated.publish_incident_channel_update"
+)
+
+
+def _neutralise_channel_maintenance(mocker: MockerFixture) -> None:
+    """Stub the Slack channel-maintenance calls that run before any publication."""
+    mocker.patch.object(IncidentChannel, "rename_if_needed")
+    mocker.patch.object(IncidentChannel, "set_incident_channel_topic")
+
+
+def _mitigating_incident():
+    """Build a saved P1/PRD incident with a channel, one step before MITIGATED."""
+    user = UserFactory.build()
+    user.save()
+    incident = IncidentFactory.build(
+        priority=Priority.objects.get(name="P1"),
+        environment=Environment.objects.get(value="PRD"),
+        created_by=user,
+        private=False,
+        _status=IncidentStatus.MITIGATING,
+    )
+    incident.save()
+    channel = IncidentChannelFactory.build(incident=incident)
+    channel.save()
+    return incident, user
+
+
+def _sent_message_types(mock_send) -> list[str]:
+    types = []
+    for call in mock_send.call_args_list:
+        message = call.args[0] if call.args else call.kwargs.get("message")
+        types.append(type(message).__name__)
+    return types
+
+
+@pytest.mark.django_db
+class TestBroadcastIsolation:
+    """A failing broadcast must not abort the incident-channel publications."""
+
+    @staticmethod
+    def test_key_events_form_sent_when_broadcast_fails(mocker: MockerFixture) -> None:
+        """The Key Events form still reaches the incident channel on broadcast failure."""
+        incident, user = _mitigating_incident()
+        _neutralise_channel_maintenance(mocker)
+        mock_send = mocker.patch.object(Conversation, "send_message_and_save")
+        mocker.patch(
+            BROADCAST_TARGET,
+            side_effect=SlackApiError("channel_not_found", response={"error": "channel_not_found"}),
+        )
+
+        incident.create_incident_update(created_by=user, status=IncidentStatus.MITIGATED)
+
+        assert "SlackMessageKeyEvents" in _sent_message_types(mock_send)
+
+    @staticmethod
+    def test_broadcast_failure_is_logged(
+        mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A swallowed broadcast failure stays observable in the logs."""
+        incident, user = _mitigating_incident()
+        _neutralise_channel_maintenance(mocker)
+        mocker.patch.object(Conversation, "send_message_and_save")
+        mocker.patch(
+            BROADCAST_TARGET,
+            side_effect=SlackApiError("channel_not_found", response={"error": "channel_not_found"}),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            incident.create_incident_update(
+                created_by=user, status=IncidentStatus.MITIGATED
+            )
+
+        assert any(
+            "incident_updated_broadcast_handler" in record.getMessage()
+            for record in caplog.records
+            if record.levelno >= logging.ERROR
+        ), "the broadcast failure must be logged, naming the receiver that failed"
+
+    @staticmethod
+    def test_broadcast_attempted_when_incident_channel_fails(
+        mocker: MockerFixture,
+    ) -> None:
+        """Isolation works both ways: a dead incident channel must not mute broadcasts."""
+        incident, user = _mitigating_incident()
+        _neutralise_channel_maintenance(mocker)
+        mocker.patch.object(Conversation, "send_message_and_save")
+        mocker.patch(
+            INCIDENT_CHANNEL_TARGET,
+            side_effect=SlackApiError("channel_not_found", response={"error": "channel_not_found"}),
+        )
+        mock_broadcast = mocker.patch(BROADCAST_TARGET)
+
+        incident.create_incident_update(created_by=user, status=IncidentStatus.MITIGATED)
+
+        mock_broadcast.assert_called_once()


### PR DESCRIPTION
A failing broadcast to an org-wide channel aborts the rest of the `incident_updated` receiver, silently dropping the Key Events form that responders rely on.

## How it fails

`publish_status_update` chained independent side effects in one function, with no isolation between them:

```
229  incident.conversation.send_message_and_save(message)   # in-channel status
235  publish_update_in_general_channel(...)                 # ← raises here
242  if incident.ask_for_milestones and ...:
252      send_message_and_save(SlackMessageKeyEvents(...))   # ← never reached
```

Reproduced with a `#critical-incidents` channel the bot cannot reach: `chat.postMessage` returns `channel_not_found`, `SlackApiError` propagates out of the function, and `Signal.send_robust()` swallows it. Nothing surfaces to the user — only an absence.

The existing guard covers the wrong case: `publish_update_in_general_channel` handles "no `Conversation` row tagged `tech_incidents`" with a warning, but not "the row exists and the channel does not".

## Why it was invisible

The two calls disagree on the status condition — the broadcast is `status == MITIGATED` (exact), the Key Events form is `status >= MITIGATED`. At Mitigated both are true, so the broadcast fails and takes the form with it. At the next transition the broadcast is not attempted, so the form goes through. The form therefore appeared one step late rather than not at all, which is why this went unnoticed.

In production `#critical-incidents` exists, so the failure is latent — until that channel is archived, made private, or the bot is removed from it.

## The fix

Split the single receiver into three, each isolated by `Signal.send_robust()` — no `try/except` needed, the framework already contains per-receiver failures and logs them:

| Receiver | Responsibility |
| --- | --- |
| `incident_updated_channel_maintenance_handler` | `rename_if_needed` + `set_incident_channel_topic` |
| `incident_updated_update_status_handler` | in-channel status message + Key Events form |
| `incident_updated_broadcast_handler` | `#critical-incidents` + `#it-deploy` |

Isolation now works both ways: a dead incident channel no longer mutes the broadcasts either — which is precisely when you want to be told.

Channel maintenance gets its own receiver because it is an even earlier failure point: `set_incident_channel_topic()` is an unguarded Slack call ahead of every publication, and it is what made the first version of the regression test fail.

`postmortem_created_handler` had the same defect — the `#critical-incidents` announcement aborted the post-mortem reminder. Isolated in place there rather than split out, because `postmortem_created` is also emitted by `firefighter.confluence.models`, so moving the announcement to a receiver would risk announcing twice.

## Verification

These code paths had **no test coverage**; this adds the first four, each failing before the fix for the right reason.

- 4 new tests passed; `test_slack/` suite 159 passed, 2 skipped
- Full suite: 19 failures, byte-identical to the set already failing on `main` (`staticfiles manifest`, `test_urls`) — no regression
- `lint-ruff` and `lint-mypy` clean

## Note for reviewers of #336

This is independent of #336 in code — it touches files that PR does not — but coupled in practice: without it, an environment whose `tech_incidents` channel is unreachable never shows the Key Events form at Mitigated, so #336's timeline review has nothing to review. Worth having both when testing that feature.

## Known limitation

The two broadcasts remain coupled to each other: a `#critical-incidents` failure still skips `#it-deploy`. Far less severe than the original defect, and the only place where a per-step isolation helper would still earn its keep.
