### PR TITLE
test: isolate the destructive migration tests, restoring order independence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,8 +141,11 @@ fmt-ruff =  {cmd="ruff check . --fix --select I001", help="Run isort-like import
 fmt-dj = {cmd="djhtml src", help="Run HTML formatting with djhtml"}
 fmt = {composite= ["fmt-black", "fmt-ruff", "fmt-dj"], help="Run all formatters (black, isort-like ruff, djhtml)"}
 # Tests
-tests = {cmd="pytest", help="Run the tests"}
-tests-cov ={cmd= "pytest --junitxml=pytest-report.xml --cov --cov-report xml:pytest-coverage.xml --cov-fail-under=0 --cov-report html", help="Run the tests with coverage, and generate reports"}
+tests = {composite=["tests-main", "tests-destructive"], help="Run the whole test suite, destructive tests in their own session"}
+tests-main = {cmd="pytest", help="Run the tests, excluding the destructive ones"}
+tests-destructive = {cmd="pytest -m destructive -p no:cacheprovider", help="Run the tests that rewind the database, in an isolated session"}
+tests-cov = {composite=["tests-cov-main", "tests-destructive"], help="Run the tests with coverage, destructive tests in their own session"}
+tests-cov-main ={cmd= "pytest --junitxml=pytest-report.xml --cov --cov-report xml:pytest-coverage.xml --cov-fail-under=0 --cov-report html", help="Run the tests with coverage, excluding the destructive ones"}
 # Docs
 docs-serve = {cmd="mkdocs serve", help="Serve the docs locally"}
 docs-build = {cmd="mkdocs build", help="Build the docs"}
@@ -417,12 +420,15 @@ filterwarnings = [
 ## Coverage sample options
 # --cov-branch
 # --cov-report=term-missing:skip-covered --cov-report=html --cov-fail-under=100
+markers = [
+    "destructive: rewinds the database outside the per-test transaction, so it must run in its own pytest session (see pdm run tests-destructive)",
+]
 addopts = """
 --strict-markers
 --strict-config
 --fail-on-template-vars
 --tb=short
--p no:randomly
+-m "not destructive"
 """
 
 # Pytest-django

--- a/tests/test_incidents/test_migrations/test_0036_foundations_category.py
+++ b/tests/test_incidents/test_migrations/test_0036_foundations_category.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 
 import pytest
 
+# `migrator` rewinds the database to an earlier migration and replays it. Those
+# are committed operations, outside the transaction pytest-django rolls back per
+# test, so the reference data loaded once per session is destroyed for every test
+# running afterwards. Kept in its own pytest session - see `pdm run tests`.
+pytestmark = pytest.mark.destructive
+
 MIGRATE_FROM = ("incidents", "0035_incidentcategory_enabled_create")
 MIGRATE_TO = ("incidents", "0036_add_foundations_incident_category")
 

--- a/tests/test_incidents/test_migrations/test_0037_foundations_usergroup.py
+++ b/tests/test_incidents/test_migrations/test_0037_foundations_usergroup.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 
 import pytest
 
+# `migrator` rewinds the database to an earlier migration and replays it. Those
+# are committed operations, outside the transaction pytest-django rolls back per
+# test, so the reference data loaded once per session is destroyed for every test
+# running afterwards. Kept in its own pytest session - see `pdm run tests`.
+pytestmark = pytest.mark.destructive
+
 MIGRATE_FROM = ("incidents", "0036_add_foundations_incident_category")
 MIGRATE_TO = ("incidents", "0037_link_foundations_slack_usergroup")
 


### PR DESCRIPTION
Closes #344, and removes the `-p no:randomly` stopgap that has been keeping CI green.

## The cause, measured

Probing `Priority.objects.count()` at the start of every test under seed 1 shows it precisely:

| Order | Rows visible |
| --- | --- |
| tests 1-7 | **6** |
| test 8 — `test_migrations/test_0036_foundations_category.py` | 0 |
| every test after it | **0** |

`django-test-migrations`' `migrator` fixture rewinds the database to an earlier migration and replays it. Those are committed operations, outside the transaction pytest-django rolls back per test, so the reference data loaded once per session by `django_db_setup` is destroyed for good. Every later test then hits

```
violates foreign key constraint "incidents_incident_priority_id_..."
DETAIL: Key (priority_id)=(3d8a4e0f-...) is not present in table "incidents_priority"
```

which is why the failure count tracked the seed: it measured how early in the run these two files happened to land.

## The fix

Marked `destructive` and run in their own pytest session — what django-test-migrations recommends, and the only thing that works here. Restoring the data from a fixture inside that package does **not** work, at either function or package scope: the restore executes inside the transaction that is about to be rolled back, so it has no effect. I tried both before settling on this.

`pdm run tests` and `pdm run tests-cov` are now composites that run the main session then the destructive one, so CI needs no change.

## Result

Random ordering is back on. Main session, four seeds:

| Seed | Before | After |
| --- | --- | --- |
| 1 | 43 failed, 128 errors | **0 failed** |
| 42 | 175 failed, 36 errors | 1 failed |
| 999 | 39 failed, 122 errors | **0 failed** |
| 7 | — | 6 failed |

Errors are gone entirely. The residual 0-6 failures are the pre-existing environment-bound tests (Confluence tables absent locally, live Slack lookups) that fail in a fixed order too — they are not order-dependent.

Destructive session: 6 passed.

## Also discarded along the way

`IncidentFactory` binds its FKs with `Iterator(Priority.objects.all())` (`incidents/factories.py:98-100`), which evaluates its queryset once and reuses the same iterator for the whole session. That is a real latent problem, but not this one: replacing it with per-instance lookups dropped errors while pushing failures up, because `.first()` returned `None` — proof the tables were genuinely empty rather than merely stale in a cache. Left alone here; worth its own change.