### PR TITLE
ci: build the front-end, so npm bumps cannot break it silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  frontend_build:
+    name: Build front-end assets
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+        with:
+          experimental: true
+      # `npm ci` is the point of this job as much as the build is: it fails on
+      # an unsatisfiable peer dependency, which is how a grouped npm bump can
+      # break the bundle. Nothing else in CI touches package.json, so without
+      # this a front-end break merges on a green check.
+      - name: Install front-end dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Check the bundles were produced
+        run: |
+          test -s src/firefighter/incidents/static/js/main.min.js
+          test -s src/firefighter/incidents/static/css/main.min.css
+
   python_build:
     name: Test and build Python
     env:


### PR DESCRIPTION
Nothing in CI touched `package.json`. The only job was `python_build`, so a bad npm bump merged on a green check and broke the bundle for everyone afterwards.

## The case in point

#339 raises `@babel/core` 7→8 inside a group of otherwise minor dev-dependency bumps, without raising `@rollup/plugin-babel`, which still requires `@babel/core@^7`. `npm ci` refuses to resolve it:

```
While resolving: @rollup/plugin-babel@7.1.0
Found: @babel/core@8.0.1
Could not resolve dependency:
  peer @babel/core@"^7.0.0" from @rollup/plugin-babel@7.1.0
Conflicting peer dependency: @babel/core@7.29.7
```

The install fails before the build even starts — and the review signal said nothing about it. Babel is not incidental here: `rollup.config.mjs` runs `babel({ babelHelpers: "bundled" })` to transpile `main.js` into `main.min.js`, which the staticfiles manifest then references.

## What this adds

A `frontend_build` job running `npm ci` then `npm run build`.

`npm ci` is as much the point as the build: it is what catches an unsatisfiable peer dependency. And since `build:js` runs rollup with `--silent`, a final step asserts both bundles are non-empty rather than trusting a quiet exit code.

Verified on `main`: install and build pass, `main.min.js` (332 KB) and `main.min.css` (138 KB) are produced, and both are gitignored so nothing leaks into the repo.

## Follow-up

#339 should be closed rather than split — even on its own, that Babel bump cannot install without `@rollup/plugin-babel` moving with it. Dependabot needs to compose a coherent batch. With this job in place, the next attempt will say so by itself.