### PR TITLE
fix(tests): raise the timeout for the destructive migration tests

### DIFF
--- a/tests/test_incidents/test_migrations/test_0036_foundations_category.py
+++ b/tests/test_incidents/test_migrations/test_0036_foundations_category.py
@@ -14,7 +14,7 @@ import pytest
 # are committed operations, outside the transaction pytest-django rolls back per
 # test, so the reference data loaded once per session is destroyed for every test
 # running afterwards. Kept in its own pytest session - see `pdm run tests`.
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.timeout(60)]
 
 MIGRATE_FROM = ("incidents", "0035_incidentcategory_enabled_create")
 MIGRATE_TO = ("incidents", "0036_add_foundations_incident_category")

--- a/tests/test_incidents/test_migrations/test_0037_foundations_usergroup.py
+++ b/tests/test_incidents/test_migrations/test_0037_foundations_usergroup.py
@@ -14,7 +14,7 @@ import pytest
 # are committed operations, outside the transaction pytest-django rolls back per
 # test, so the reference data loaded once per session is destroyed for every test
 # running afterwards. Kept in its own pytest session - see `pdm run tests`.
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.timeout(60)]
 
 MIGRATE_FROM = ("incidents", "0036_add_foundations_incident_category")
 MIGRATE_TO = ("incidents", "0037_link_foundations_slack_usergroup")


### PR DESCRIPTION
`main` is red on 543f8c75. This is a pre-existing flake in the destructive session, not a regression from that merge.

## Diagnosis

`test_0036_foundations_category.py` and `test_0037_foundations_usergroup.py` hold the only `destructive` tests. Each of their six tests replays the whole migration chain through `migrator.apply_initial_migration` — about 6s each locally, more on a CI runner — while running under the global `timeout = 15` in `pyproject.toml`, a ceiling meant for unit tests.

`pytest-randomly` reshuffles the session on every run, and whichever test lands first pays the cold cost. The same code therefore passes or fails depending on the seed:

| Run | Seed | First destructive test | Result |
| --- | --- | --- | --- |
| PR #352 | 3001743060 | `test_0037_foundations_usergroup.py` | 6 passed |
| main 543f8c75 | 2376274404 | `test_0036_foundations_category.py` | timeout after 15s |

The traceback confirms real migration work rather than a hang — it stops inside `_migrate_all_forwards`, in `incidents/migrations/0014_update_components_slack_groups.py:78`, on `get_or_create` calls instrumented by `nplusone`.

## Fix

Extend the existing module-level `pytestmark` in both files:

```python
pytestmark = [pytest.mark.destructive, pytest.mark.timeout(60)]
```

Applied to all six tests rather than only the one that happened to fail, since they all replay the same chain and carry the same risk. 60s keeps roughly 4x headroom over what CI showed while still catching a genuine hang. The marker follows the precedent already in `tests/test_firefighter/test_urls.py:133`.

## Verification

- Forcing `--timeout=1` on the command line, the six tests still pass in 56.50s — proving the `timeout(60)` marker takes precedence and is genuinely applied
- `pytest --collect-only` on the main session collects **0** of these tests, so turning `pytestmark` into a list did not weaken the `destructive` exclusion
- `pdm run tests-destructive` locally: 6 passed, slowest test 6.59s

Note that a green run on this PR is not by itself proof, since the seed may simply be favourable; the two checks above are what establish the fix.