### PR TITLE
feat(atlas): name the incident commander in the analysis request

### DIFF
--- a/src/firefighter/atlas/tasks/request_analysis.py
+++ b/src/firefighter/atlas/tasks/request_analysis.py
@@ -56,6 +56,10 @@ def request_incident_analysis(self: Any, incident_id: int, slack_channel_id: str
     2. Async self-invoke its internal component to run a multi-track investigation.
     3. Post a ranked root-cause analysis (Block Kit) into ``slack_channel_id``.
 
+    The payload names the incident commander so that Atlas can credit the analysis
+    to a human: what it posts is an unreviewed hypothesis, and it cannot own its own
+    claims. When nobody holds command, Atlas says so in its own words.
+
     Args:
         self: Celery task instance (bound task).
         incident_id: PK of the ``Incident`` to analyse.
@@ -71,13 +75,19 @@ def request_incident_analysis(self: Any, incident_id: int, slack_channel_id: str
 
     from firefighter.firefighter.http_client import HttpClient
     from firefighter.incidents.models.incident import Incident
+    from firefighter.slack.slack_templating import user_slack_handle_or_name
 
     try:
-        incident = Incident.objects.select_related(
-            "priority",
-            "environment",
-            "incident_category",
-        ).get(id=incident_id)
+        incident = (
+            Incident.objects.select_related(
+                "priority",
+                "environment",
+                "incident_category",
+            )
+            # `commander` scans `roles_set`, so select_related cannot reach it.
+            .prefetch_related("roles_set__role_type", "roles_set__user__slack_user")
+            .get(id=incident_id)
+        )
     except Incident.DoesNotExist:
         logger.error(  # noqa: TRY400
             "Atlas task: incident %s not found, aborting analysis",
@@ -85,6 +95,17 @@ def request_incident_analysis(self: Any, incident_id: int, slack_channel_id: str
             extra={"incident_id": incident_id},
         )
         return
+
+    # Prefer the Slack mention so the Atlas report footer pings whoever owns it;
+    # fall back to the full name for a commander with no linked Slack user. Both
+    # levels can legitimately be absent, and the helper's "no user" sentinel is not
+    # something Atlas should print, so guard rather than pass None through.
+    commander_role = incident.commander
+    commander: str | None = (
+        user_slack_handle_or_name(commander_role.user)
+        if commander_role and commander_role.user
+        else None
+    )
 
     payload: dict[str, Any] = {
         "incident_id": str(incident.id),
@@ -96,6 +117,7 @@ def request_incident_analysis(self: Any, incident_id: int, slack_channel_id: str
         "environment": incident.environment.value.lower(),
         "occurred_at": incident.created_at.isoformat(),
         "slack_channel_id": slack_channel_id,
+        "commander": commander,
     }
 
     # Sign the exact bytes we will send so Atlas can verify integrity.

--- a/tests/test_atlas/test_tasks.py
+++ b/tests/test_atlas/test_tasks.py
@@ -14,6 +14,14 @@ from firefighter.atlas.tasks.request_analysis import request_incident_analysis
 from firefighter.incidents.models.incident import Incident
 
 
+def _make_commander(slack_id: str | None = "U123", full_name: str = "Jane Doe") -> Mock:
+    """An `IncidentRole` holding command, shaped as `user_slack_handle_or_name` reads it."""
+    role = Mock()
+    role.user.full_name = full_name
+    role.user.slack_user = Mock(slack_id=slack_id) if slack_id else None
+    return role
+
+
 def _make_incident(env_value: str = "PRD", priority_name: str = "P1") -> Mock:
     incident = Mock()
     incident.id = 42
@@ -24,14 +32,29 @@ def _make_incident(env_value: str = "PRD", priority_name: str = "P1") -> Mock:
     incident.description = "Something is broken"
     incident.incident_category.name = "checkout"
     incident.created_at.isoformat.return_value = "2024-01-01T00:00:00+00:00"
+    # Must be explicit: a bare Mock attribute is not JSON-serialisable.
+    incident.commander = _make_commander()
     return incident
 
 
-def _mock_select_related(incident: Mock) -> Mock:
+def _mock_queryset(incident: Mock) -> Mock:
     qs = MagicMock()
     qs.select_related.return_value = qs
+    qs.prefetch_related.return_value = qs
     qs.get.return_value = incident
     return qs
+
+
+def _sent_payload(mock_instance: Mock) -> dict:
+    """Decode the exact bytes POSTed, so assertions cover the signed body."""
+    return json.loads(mock_instance.post.call_args.kwargs["content"].decode("utf-8"))
+
+
+def _ok_response() -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    return response
 
 
 def _setup_http_client_mock(mock_client_cls: Mock, mock_response: Mock) -> Mock:
@@ -58,7 +81,7 @@ def test_posts_payload_to_atlas() -> None:
     mock_response.raise_for_status.return_value = None
 
     with (
-        patch("firefighter.incidents.models.incident.Incident.objects", _mock_select_related(incident)),
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
         patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
     ):
         mock_instance = _setup_http_client_mock(mock_client_cls, mock_response)
@@ -87,10 +110,75 @@ def test_posts_payload_to_atlas() -> None:
 
 
 @override_settings(ATLAS_URL="https://atlas.example.com/platform-ops/incident/analyze", ATLAS_SHARED_SECRET="secret")  # noqa: S106
+def test_sends_the_commander_as_a_slack_mention() -> None:
+    """Atlas drops the value into a mrkdwn footer, so a mention renders and pings."""
+    incident = _make_incident()
+    incident.commander = _make_commander(slack_id="U456")
+
+    with (
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
+        patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
+    ):
+        mock_instance = _setup_http_client_mock(mock_client_cls, _ok_response())
+        request_incident_analysis.apply(args=[42, "C123"]).get()
+
+        assert _sent_payload(mock_instance)["commander"] == "<@U456>"
+
+
+@override_settings(ATLAS_URL="https://atlas.example.com/platform-ops/incident/analyze", ATLAS_SHARED_SECRET="secret")  # noqa: S106
+def test_falls_back_to_the_commander_full_name_without_a_slack_user() -> None:
+    incident = _make_incident()
+    incident.commander = _make_commander(slack_id=None, full_name="Jane Doe")
+
+    with (
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
+        patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
+    ):
+        mock_instance = _setup_http_client_mock(mock_client_cls, _ok_response())
+        request_incident_analysis.apply(args=[42, "C123"]).get()
+
+        assert _sent_payload(mock_instance)["commander"] == "Jane Doe"
+
+
+@override_settings(ATLAS_URL="https://atlas.example.com/platform-ops/incident/analyze", ATLAS_SHARED_SECRET="secret")  # noqa: S106
+def test_commander_is_null_when_nobody_holds_command() -> None:
+    """Atlas supplies its own "unassigned" wording; never send the ∅ sentinel."""
+    incident = _make_incident()
+    incident.commander = None
+
+    with (
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
+        patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
+    ):
+        mock_instance = _setup_http_client_mock(mock_client_cls, _ok_response())
+        request_incident_analysis.apply(args=[42, "C123"]).get()
+
+        assert _sent_payload(mock_instance)["commander"] is None
+
+
+@override_settings(ATLAS_URL="https://atlas.example.com/platform-ops/incident/analyze", ATLAS_SHARED_SECRET="secret")  # noqa: S106
+def test_commander_is_null_when_the_role_has_no_user() -> None:
+    incident = _make_incident()
+    role = Mock()
+    role.user = None
+    incident.commander = role
+
+    with (
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
+        patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
+    ):
+        mock_instance = _setup_http_client_mock(mock_client_cls, _ok_response())
+        request_incident_analysis.apply(args=[42, "C123"]).get()
+
+        assert _sent_payload(mock_instance)["commander"] is None
+
+
+@override_settings(ATLAS_URL="https://atlas.example.com/platform-ops/incident/analyze", ATLAS_SHARED_SECRET="secret")  # noqa: S106
 def test_aborts_when_incident_missing() -> None:
     """C2: DoesNotExist is caught — task succeeds cleanly with no HTTP call."""
     qs = MagicMock()
     qs.select_related.return_value = qs
+    qs.prefetch_related.return_value = qs
     qs.get.side_effect = Incident.DoesNotExist
 
     with (
@@ -116,7 +204,7 @@ def test_does_not_retry_on_4xx() -> None:
     mock_response.raise_for_status.side_effect = http_error
 
     with (
-        patch("firefighter.incidents.models.incident.Incident.objects", _mock_select_related(incident)),
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
         patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
     ):
         _setup_http_client_mock(mock_client_cls, mock_response)
@@ -137,7 +225,7 @@ def test_retries_on_5xx() -> None:
     mock_response.raise_for_status.side_effect = http_error
 
     with (
-        patch("firefighter.incidents.models.incident.Incident.objects", _mock_select_related(incident)),
+        patch("firefighter.incidents.models.incident.Incident.objects", _mock_queryset(incident)),
         patch("firefighter.firefighter.http_client.HttpClient") as mock_client_cls,
     ):
         _setup_http_client_mock(mock_client_cls, mock_response)


### PR DESCRIPTION
## Why

Atlas posts an AI-assisted root-cause analysis into the incident channel. By its own guidelines it cannot own the hypothesis it just published, so the report footer names the human who does — read from an optional `commander` field on the trigger payload:

```python
# platform-ops · platform_ops/incident_trigger.py
commander: str | None = event.get("commander") or None
```
```python
# platform-ops · platform_ops/slack/incident_blocks.py
f":warning: *AI-assisted analysis · unverified hypothesis* — owner: "
f"{commander or _UNREVIEWED_OWNER}. Verify before quoting it in the postmortem. "
```

The Atlas side has shipped and its tests pin the behaviour. FireFighter never sent the field, so **every report so far has footered as `owner: incident commander (unassigned)`** even when someone held command.

## What

`src/firefighter/atlas/tasks/request_analysis.py` now sends `commander` in the payload.

- **Value** — the Slack mention when the commander has a linked Slack user, so the footer pings whoever owns the analysis; the full name otherwise. This reuses `user_slack_handle_or_name()` (`slack/slack_templating.py`), which already makes exactly that choice everywhere else in the Slack messages.
- **Fetch** — `Incident.commander` is a property scanning `roles_set`, not a foreign key, so `select_related` cannot reach it. The query gains the prefetch pair the property's docstring prescribes: `prefetch_related("roles_set__role_type", "roles_set__user__slack_user")`.
- **Absent commander** — `null` goes out when nobody holds command, or when the role carries no user (both guarded the way `commander_ownership_block()` guards them). Atlas supplies its own "unassigned" wording, and the helper's `∅` sentinel must not reach it.
- **Signing** — no change needed. The HMAC is computed over the serialised payload, so the new field is inside the signed body.

## Tests

`tests/test_atlas/test_tasks.py` — four new cases: Slack mention, full-name fallback, `null` when nobody holds command, `null` when the role has no user. Each asserts against the decoded `content=` bytes actually POSTed rather than the dict that produced them, so they also prove the field is in the signed body.

Two fixture fixes were required, not cosmetic:

- `_make_incident()` returns a bare `Mock`, so `incident.commander` would auto-vivify and `json.dumps` would raise `TypeError` — the pre-existing `test_posts_payload_to_atlas` would have broken without an explicit commander.
- `_mock_select_related` → `_mock_queryset`, with `prefetch_related` wired to return itself; otherwise the chained call yields a fresh `MagicMock` and `.get()` never returns the incident.

## Verification

```
pytest tests/test_atlas/ -q     19 passed
ruff check                      all checks passed
mypy src/firefighter/atlas/     no issues found in 5 source files
```

End to end, the footer should read `owner: @<commander>` instead of `owner: incident commander (unassigned)`. The contract can also be replayed without Slack from the `platform-ops` side via `scripts/run_local.py --dry-run` against a payload file in `local-incidents/`.
