### PR TITLE
feat(incidents): require Recovered, the key event the SLA stops on

### DIFF
--- a/src/firefighter/incidents/timeline.py
+++ b/src/firefighter/incidents/timeline.py
@@ -37,6 +37,7 @@ MILESTONE_EVENT_TYPES: tuple[tuple[str, str], ...] = (
     ("started", "Started"),
     ("detected", "Detected"),
 )
+"""The milestones that *precede* the declaration, in `get_incident_timeline`."""
 
 # The seven key events of an incident, in the order they are expected to happen.
 # This interleaving of milestones and statuses lives nowhere else: MilestoneType
@@ -55,10 +56,29 @@ EXPECTED_STEPS: tuple[tuple[str, str, str | IncidentStatus, bool], ...] = (
     ("Investigating", ":mag:", IncidentStatus.INVESTIGATING, False),
     ("Mitigating", ":wrench:", IncidentStatus.MITIGATING, False),
     ("Mitigated", ":white_check_mark:", IncidentStatus.MITIGATED, False),
+    # Recovered is where the SLA clock stops (Recovered - Declared, the
+    # `time_to_fix` metric), so it is required like the other milestones: an
+    # incident without it cannot be graded against its target at all.
+    ("Recovered", ":checkered_flag:", "recovered", True),
     ("Post-mortem", ":memo:", IncidentStatus.POST_MORTEM, False),
 )
 
 EXPECTED_ORDER: tuple[str, ...] = tuple(label for label, *_ in EXPECTED_STEPS)
+
+# Recovered records when the impact ceased - business time, typed by hand -
+# while Mitigated is a status transition clicked in Slack. Measured on the
+# support data: the two carry the same timestamp on 77% of incidents, Recovered
+# comes first on 19.6% and later on 3.2%. Checking it against its neighbour in
+# the sequence would therefore flag one incident in five for nothing, so it is
+# checked against the declaration instead - which is exactly what its metric
+# needs, `time_to_fix` being Recovered - Declared and never negative.
+UNORDERED_STEPS: frozenset[str] = frozenset({"Recovered"})
+
+CANONICAL_MILESTONE_EVENT_TYPES: tuple[str, ...] = tuple(
+    source for _label, _emoji, source, _required in EXPECTED_STEPS
+    if isinstance(source, str)
+)
+"""Every milestone of the canonical timeline, wherever it sits in the sequence."""
 
 # What each status means, in the same voice as `MilestoneType.summary` ("when
 # the first issues arose"), which supplies the milestones' own definitions. The
@@ -197,6 +217,9 @@ def find_timeline_issues(steps: list[TimelineStep]) -> list[TimelineIssue]:
     """
     issues: list[TimelineIssue] = []
     right_now = now()
+    declared_at = next(
+        (step.event_ts for step in steps if step.label == "Declared"), None
+    )
     previous: tuple[str, datetime.datetime] | None = None
     for step in steps:
         label = step.label
@@ -211,6 +234,19 @@ def find_timeline_issues(steps: list[TimelineStep]) -> list[TimelineIssue]:
             continue
         if event_ts > right_now:
             issues.append(TimelineIssue(label, f"*{label}* is in the future"))
+        if label in UNORDERED_STEPS:
+            # Anchored to the declaration rather than to the previous step, and
+            # left out of the chain so the next step is not compared to it.
+            if declared_at is not None and event_ts < declared_at:
+                issues.append(
+                    TimelineIssue(
+                        label,
+                        f"*{label}* ({localtime(event_ts).strftime('%H:%M:%S')}) is "
+                        f"{format_delta(declared_at - event_ts)} before *Declared* "
+                        f"({localtime(declared_at).strftime('%H:%M:%S')})",
+                    )
+                )
+            continue
         if previous is not None and event_ts < previous[1]:
             issues.append(
                 TimelineIssue(
@@ -247,7 +283,7 @@ def milestone_timestamps(incident: Incident) -> dict[str, datetime.datetime]:
     """
     rows = (
         incident.incidentupdate_set.filter(
-            event_type__in=[event_type for event_type, _ in MILESTONE_EVENT_TYPES]
+            event_type__in=CANONICAL_MILESTONE_EVENT_TYPES
         )
         .order_by("event_ts")
         .values_list("event_type", "event_ts")

--- a/tests/test_incidents/test_timeline.py
+++ b/tests/test_incidents/test_timeline.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from django.utils import timezone
 
 from firefighter.incidents.enums import IncidentStatus
 from firefighter.incidents.factories import IncidentFactory, UserFactory
+from firefighter.incidents.models.incident import Incident
 from firefighter.incidents.models.incident_update import IncidentUpdate
 from firefighter.incidents.timeline import (
     TimelineEntry,
+    TimelineStep,
+    find_timeline_issues,
+    get_canonical_steps,
     get_incident_timeline,
     get_status_timeline,
 )
-
-if TYPE_CHECKING:
-    from firefighter.incidents.models.incident import Incident
 
 
 @pytest.mark.django_db
@@ -238,3 +237,114 @@ class TestGetIncidentTimeline:
             TimelineEntry(label="Declared", event_ts=incident.created_at),
             TimelineEntry(label="Open", event_ts=reopened_at),
         ]
+
+
+@pytest.mark.django_db
+class TestRecoveredStep:
+    """Recovered closes the timeline: it is where the SLA clock stops.
+
+    `time_to_fix` is `Recovered - Declared`, so an incident without Recovered
+    cannot be graded against its target at all - hence required. But it is
+    business time typed by hand, while Mitigated is a status transition clicked
+    in Slack: on the support data the two share a timestamp on 77% of
+    incidents, Recovered comes first on 19.6% and later on 3.2%. Ordering it
+    against its neighbour would flag one incident in five for nothing.
+    """
+
+    @staticmethod
+    def _steps(incident: Incident) -> list[TimelineStep]:
+        return get_canonical_steps(incident)
+
+    @staticmethod
+    def test_missing_recovered_is_reported() -> None:
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        for event_type in ("started", "detected"):
+            IncidentUpdate.objects.create(
+                incident=incident,
+                event_type=event_type,
+                event_ts=incident.created_at - timezone.timedelta(hours=1),
+                created_by=user,
+            )
+
+        issues = find_timeline_issues(get_canonical_steps(incident))
+
+        assert any(
+            "Recovered" in issue.message and "required" in issue.message
+            for issue in issues
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize("offset_minutes", [-30, 0, 30])
+    def test_recovered_is_not_ordered_against_mitigated(offset_minutes: int) -> None:
+        """Before, at the same instant, or after: none of them is an issue."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        # `created_at` is auto_now_add, so the whole timeline is pushed into
+        # yesterday - otherwise anything after the declaration reads as future.
+        Incident.objects.filter(pk=incident.pk).update(
+            created_at=timezone.now() - timezone.timedelta(days=1)
+        )
+        incident.refresh_from_db()
+        user = UserFactory.create()
+        mitigated_at = incident.created_at + timezone.timedelta(hours=2)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            _status=IncidentStatus.MITIGATED,
+            event_ts=mitigated_at,
+            created_by=user,
+        )
+        for event_type, ts in (
+            ("started", incident.created_at - timezone.timedelta(hours=2)),
+            ("detected", incident.created_at - timezone.timedelta(hours=1)),
+            (
+                "recovered",
+                mitigated_at + timezone.timedelta(minutes=offset_minutes),
+            ),
+        ):
+            IncidentUpdate.objects.create(
+                incident=incident, event_type=event_type, event_ts=ts, created_by=user
+            )
+
+        issues = find_timeline_issues(get_canonical_steps(incident))
+
+        assert [issue for issue in issues if issue.label == "Recovered"] == []
+
+    @staticmethod
+    def test_recovered_before_the_declaration_is_reported() -> None:
+        """`time_to_fix` would be negative - the metric itself refuses that."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        user = UserFactory.create()
+        for event_type, ts in (
+            ("started", incident.created_at - timezone.timedelta(hours=3)),
+            ("detected", incident.created_at - timezone.timedelta(hours=2)),
+            ("recovered", incident.created_at - timezone.timedelta(hours=1)),
+        ):
+            IncidentUpdate.objects.create(
+                incident=incident, event_type=event_type, event_ts=ts, created_by=user
+            )
+
+        issues = find_timeline_issues(get_canonical_steps(incident))
+
+        assert any(
+            issue.label == "Recovered" and "before *Declared*" in issue.message
+            for issue in issues
+        )
+
+    @staticmethod
+    def test_recovered_is_read_back_into_the_canonical_steps() -> None:
+        """It used to be fetched by no one, so the form always showed it empty."""
+        incident: Incident = IncidentFactory.create(_status=IncidentStatus.MITIGATED)
+        recovered_at = incident.created_at + timezone.timedelta(hours=1)
+        IncidentUpdate.objects.create(
+            incident=incident,
+            event_type="recovered",
+            event_ts=recovered_at,
+            created_by=UserFactory.create(),
+        )
+
+        step = next(
+            step for step in get_canonical_steps(incident) if step.label == "Recovered"
+        )
+
+        assert step.event_ts == recovered_at
+        assert step.required is True

--- a/tests/test_slack/views/modals/test_review_timeline.py
+++ b/tests/test_slack/views/modals/test_review_timeline.py
@@ -59,6 +59,16 @@ def record_consistent_timeline(incident: Incident) -> None:
         event_ts=incident.created_at - timezone.timedelta(hours=1),
         created_by=user,
     )
+    # Recovered closes the sequence: it is where the SLA clock stops, so the
+    # consistency gate now requires it like the milestones that open it. Anchored
+    # to the declaration itself: the factory declares the incident at "now", so
+    # anything later would read as a time in the future.
+    IncidentUpdate.objects.create(
+        incident=incident,
+        event_type="recovered",
+        event_ts=incident.created_at,
+        created_by=user,
+    )
 
 
 class TestBuildCarryOverPayload:


### PR DESCRIPTION
## Why

The SLA our incident process reports on is `time_to_fix` — Recovered minus Declared. An incident with no recorded **Recovered** therefore cannot be graded against its target at all, and **22% of incidents have none** (2 848 of 3 659 on the support data).

Recovered was in the timeline correction form and nowhere else: absent from the preview, unknown to the consistency checks, and no obstacle to reaching Post-mortem. So the one key event the SLA depends on was the least defended of them all.

It is now a canonical step, required like the milestones that open the timeline. When it is missing, `find_timeline_issues` reports it — which already withholds the *continue to Post-mortem* button and makes the handler refuse the transition, so the gate needed no new mechanism.

## Not ordered against its neighbour

Recovered is business time typed by hand; Mitigated is a status transition clicked in Slack. Measured on the support data across 2 701 incidents that have both:

| Recovered vs the Mitigated transition | |
| --- | --- |
| same timestamp | 2 084 (77.2%) |
| Recovered first | 530 (19.6%) |
| Recovered later | 87 (3.2%) |

Ordering it against the previous step would have flagged **one incident in five** for nothing. It is therefore left out of the ordering chain and anchored to the declaration instead: `Recovered < Declared` (130 incidents, 4.6%) is a real inconsistency — the one `compute_metrics` already refuses to store as a negative duration.

## Also fixed

`milestone_timestamps()` only ever fetched Started and Detected, so a recorded Recovered never reached the form, which always rendered it empty. It now reads every canonical milestone.

## Tests

Four cases in `tests/test_incidents/test_timeline.py`, including one parametrised over the three positions of Recovered relative to Mitigated (before / same instant / after), each asserting no issue is raised. The suite's `record_consistent_timeline` helper records Recovered at the declaration, the degenerate-but-normal case that 77% of real incidents exhibit.
