### PR TITLE
feat(slack): trigger the Dust post-mortem agent through its webhook

### DIFF
--- a/docs/deploy/XX-settings.md
+++ b/docs/deploy/XX-settings.md
@@ -80,7 +80,9 @@ See [django-oauth2-codeflow](https://gitlab.com/systra/qeto/lib/django-oauth2-au
 ### Dust AI integration (optional)
 
 - [`ENABLE_DUST`][firefighter.firefighter.settings.components.slack.ENABLE_DUST]: set to `True` to show the "Generate post-mortem with Dust" button in Jira post-mortem Slack messages.
-- [`DUST_SLACK_BOT_NAME`][firefighter.firefighter.settings.components.slack.DUST_SLACK_BOT_NAME]: Slack display name of the Dust app (default: `dust`). Used to resolve its user ID at runtime to invite it to the incident channel and mention it.
+- [`DUST_SLACK_BOT_NAME`][firefighter.firefighter.settings.components.slack.DUST_SLACK_BOT_NAME]: Slack display name of the Dust app (default: `dust`). Used to resolve its user ID at runtime, to invite it to the incident channel so it can answer there.
+- [`DUST_WEBHOOK_URL`][firefighter.firefighter.settings.components.slack.DUST_WEBHOOK_URL]: the Dust webhook that triggers the post-mortem agent. Required for the button to do anything.
+- [`DUST_WEBHOOK_SECRET`][firefighter.firefighter.settings.components.slack.DUST_WEBHOOK_SECRET]: the shared secret configured on that webhook. The payload is signed with HMAC-SHA256 and sent as `signature: sha256=<hex>`. Without both URL and secret the trigger is skipped rather than issuing a call the webhook would reject.
 
 ## Confluence integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ fmt = {composite= ["fmt-black", "fmt-ruff", "fmt-dj"], help="Run all formatters 
 # Tests
 tests = {composite=["tests-main", "tests-destructive"], help="Run the whole test suite, destructive tests in their own session"}
 tests-main = {cmd="pytest", help="Run the tests, excluding the destructive ones"}
-tests-destructive = {cmd="pytest -m destructive -p no:cacheprovider", help="Run the tests that rewind the database, in an isolated session"}
+tests-destructive = {cmd="pytest -m destructive -p no:cacheprovider --create-db", help="Run the tests that rewind the database, in an isolated session on a freshly created one"}
 tests-cov = {composite=["tests-cov-main", "tests-destructive"], help="Run the tests with coverage, destructive tests in their own session"}
 tests-cov-main ={cmd= "pytest --junitxml=pytest-report.xml --cov --cov-report xml:pytest-coverage.xml --cov-fail-under=0 --cov-report html", help="Run the tests with coverage, excluding the destructive ones"}
 # Docs

--- a/src/firefighter/firefighter/settings/components/slack.py
+++ b/src/firefighter/firefighter/settings/components/slack.py
@@ -59,6 +59,20 @@ ENABLE_DUST: bool = config("ENABLE_DUST", cast=bool, default=False)
 DUST_SLACK_BOT_NAME: str = config("DUST_SLACK_BOT_NAME", default="dust")
 """Slack display name of the Dust app (used to resolve its user ID at runtime)."""
 
+DUST_WEBHOOK_URL: str | None = config("DUST_WEBHOOK_URL", default=None)
+"""Dust webhook that triggers the post-mortem agent.
+
+Posting an instruction in the channel and hoping the agent picks it up proved
+unreliable; Dust exposes a webhook for this, which is called directly instead.
+"""
+DUST_WEBHOOK_SECRET: str | None = config("DUST_WEBHOOK_SECRET", default=None)
+"""Shared secret signing the webhook payload (HMAC-SHA256, `signature: sha256=<hex>`).
+
+Same scheme as the inbound Jira webhooks (see `api.authentication`), in the
+other direction. Fed by Vault; without it the trigger is skipped rather than
+sending an unsigned call the webhook would reject anyway.
+"""
+
 FF_TIMELINE_SYNC_DEBOUNCE_SECONDS: int = config(
     "FF_TIMELINE_SYNC_DEBOUNCE_SECONDS", cast=int, default=30
 )

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -55,16 +55,28 @@ def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
     return None
 
 
-def build_dust_message(incident: Incident, jira_issue_key: str) -> str:
-    """The instruction handed to the agent: which channel to read, which ticket to fill."""
+def build_dust_payload(incident: Incident, jira_issue_key: str) -> dict[str, Any]:
+    """What the agent is given: the channel to read and the ticket to fill in.
+
+    Dust does not impose a schema - "you define the structure based on your
+    webhook source", and the agent's instructions and filters address the
+    fields by path. So the two values the agent needs are sent as fields it can
+    address directly, and `message` carries the same thing as prose for an
+    agent that would rather read the instruction than the structure.
+    """
     channel = incident.conversation
-    return (
-        f"Please fill in the post-mortem Jira ticket {jira_issue_key} for incident "
-        f"#{incident.id} ({incident.title}). The incident was handled in the Slack "
-        f"channel #{channel.name} ({channel.channel_id}): read through it and "
-        "complete the post-mortem with the summary, timeline, root cause, impact "
-        "and action items."
-    )
+    return {
+        "message": (
+            f"Please fill in the post-mortem Jira ticket {jira_issue_key} for incident "
+            f"#{incident.id} ({incident.title}). The incident was handled in the Slack "
+            f"channel #{channel.name} ({channel.channel_id}): read through it and "
+            "complete the post-mortem with the summary, timeline, root cause, impact "
+            "and action items."
+        ),
+        "jira_issue_key": jira_issue_key,
+        "channel": {"id": channel.channel_id, "name": channel.name},
+        "incident": {"id": incident.id, "title": incident.title},
+    }
 
 
 def sign_payload(body: bytes, secret: str) -> str:
@@ -73,14 +85,14 @@ def sign_payload(body: bytes, secret: str) -> str:
     return f"{SIGNATURE_PREFIX}{digest}"
 
 
-def _call_dust_webhook(url: str, secret: str, message: str) -> None:
+def _call_dust_webhook(url: str, secret: str, payload: dict[str, Any]) -> None:
     """POST the signed payload.
 
     The body is serialized once and sent as raw bytes: signing a dict and
     letting the HTTP client re-serialize it would produce a signature over
     different bytes than the ones on the wire.
     """
-    body = json.dumps({"message": message}).encode("utf-8")
+    body = json.dumps(payload).encode("utf-8")
     headers = {
         "Content-Type": "application/json",
         SIGNATURE_HEADER: sign_payload(body, secret),
@@ -149,7 +161,7 @@ def generate_dust_postmortem(
     _call_dust_webhook(
         webhook_url,
         webhook_secret,
-        build_dust_message(incident, jira_postmortem.jira_issue_key),
+        build_dust_payload(incident, jira_postmortem.jira_issue_key),
     )
     logger.info(
         "Called the Dust webhook for incident %s (post-mortem %s)",

--- a/src/firefighter/slack/tasks/generate_dust_postmortem.py
+++ b/src/firefighter/slack/tasks/generate_dust_postmortem.py
@@ -1,12 +1,28 @@
+"""Ask the Dust agent to fill in an incident's post-mortem.
+
+The first implementation posted an instruction addressed to the Dust bot in the
+incident channel and relied on the agent reading it. It did not work reliably,
+so Dust exposes a webhook for exactly this: the payload names the channel to
+work from and the Jira post-mortem to fill, and is signed with a shared secret.
+
+The bot is still invited to the channel first: the agent reports back there, and
+a bot that is not a member cannot post.
+"""
+
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from celery import shared_task
 from django.conf import settings
 from slack_sdk.errors import SlackApiError
 
+from firefighter.firefighter.http_client import HttpClient
 from firefighter.slack.slack_app import DefaultWebClient, slack_client
 
 if TYPE_CHECKING:
@@ -15,6 +31,9 @@ if TYPE_CHECKING:
     from firefighter.incidents.models.incident import Incident
 
 logger = logging.getLogger(__name__)
+
+SIGNATURE_HEADER = "signature"
+SIGNATURE_PREFIX = "sha256="
 
 
 def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
@@ -36,25 +55,44 @@ def _resolve_bot_user_id(client: WebClient, bot_name: str) -> str | None:
     return None
 
 
-def _build_dust_message(bot_user_id: str, incident: Incident) -> str:
-    """Build the English instruction posted to the Dust agent in the channel."""
-    jira_pm = getattr(incident, "jira_postmortem_for", None)
-    ticket_ref = (
-        f"the post-mortem Jira ticket <{jira_pm.issue_url}|{jira_pm.jira_issue_key}>"
-        if jira_pm is not None
-        else "the post-mortem for this incident"
-    )
+def build_dust_message(incident: Incident, jira_issue_key: str) -> str:
+    """The instruction handed to the agent: which channel to read, which ticket to fill."""
+    channel = incident.conversation
     return (
-        f"<@{bot_user_id}> ~IncidentManagementPostMortem "
-        f"Please update {ticket_ref} for this incident. "
-        "Read through this incident channel and fill in the post-mortem: "
-        "summary, timeline, root cause, impact, and action items."
+        f"Please fill in the post-mortem Jira ticket {jira_issue_key} for incident "
+        f"#{incident.id} ({incident.title}). The incident was handled in the Slack "
+        f"channel #{channel.name} ({channel.channel_id}): read through it and "
+        "complete the post-mortem with the summary, timeline, root cause, impact "
+        "and action items."
     )
+
+
+def sign_payload(body: bytes, secret: str) -> str:
+    """`sha256=<hex>` HMAC of the exact bytes sent, as the webhook expects."""
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"{SIGNATURE_PREFIX}{digest}"
+
+
+def _call_dust_webhook(url: str, secret: str, message: str) -> None:
+    """POST the signed payload.
+
+    The body is serialized once and sent as raw bytes: signing a dict and
+    letting the HTTP client re-serialize it would produce a signature over
+    different bytes than the ones on the wire.
+    """
+    body = json.dumps({"message": message}).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        SIGNATURE_HEADER: sign_payload(body, secret),
+    }
+    with HttpClient() as client:
+        response = client.post(url, content=body, headers=headers)
+    response.raise_for_status()
 
 
 @shared_task(
     name="slack.generate_dust_postmortem",
-    autoretry_for=(SlackApiError,),
+    autoretry_for=(SlackApiError, httpx.HTTPError),
     retry_kwargs={"max_retries": 2},
     default_retry_delay=30,
 )
@@ -69,28 +107,52 @@ def generate_dust_postmortem(
         "conversation", "jira_postmortem_for"
     ).get(id=incident_id)
     if not hasattr(incident, "conversation"):
-        logger.warning("Incident %s has no Slack channel, skipping Dust trigger", incident_id)
+        logger.warning(
+            "Incident %s has no Slack channel, skipping Dust trigger", incident_id
+        )
         return
 
-    bot_name: str = settings.DUST_SLACK_BOT_NAME
-    bot_user_id = _resolve_bot_user_id(client, bot_name)
-    if not bot_user_id:
-        logger.warning("Dust bot '%s' not found in workspace, skipping Dust trigger", bot_name)
+    jira_postmortem = getattr(incident, "jira_postmortem_for", None)
+    if jira_postmortem is None:
+        # The agent's whole job is to fill that ticket in; without one there is
+        # nothing for it to write to.
+        logger.warning(
+            "Incident %s has no Jira post-mortem, skipping Dust trigger", incident_id
+        )
+        return
+
+    webhook_url: str | None = settings.DUST_WEBHOOK_URL
+    webhook_secret: str | None = settings.DUST_WEBHOOK_SECRET
+    if not webhook_url or not webhook_secret:
+        logger.warning(
+            "Dust webhook is not configured (URL or secret missing), skipping Dust trigger"
+        )
         return
 
     channel_id: str = incident.conversation.channel_id
-
-    try:
-        client.conversations_invite(channel=channel_id, users=[bot_user_id])
-        logger.info("Invited Dust bot %s to channel %s", bot_user_id, channel_id)
-    except SlackApiError as e:
-        if e.response.get("error") == "already_in_channel":
+    bot_name: str = settings.DUST_SLACK_BOT_NAME
+    bot_user_id = _resolve_bot_user_id(client, bot_name)
+    if bot_user_id:
+        # Best effort: the agent answers in the channel, so it has to be a member.
+        try:
+            client.conversations_invite(channel=channel_id, users=[bot_user_id])
+            logger.info("Invited Dust bot %s to channel %s", bot_user_id, channel_id)
+        except SlackApiError as e:
+            if e.response.get("error") != "already_in_channel":
+                raise
             logger.info("Dust bot already in channel %s", channel_id)
-        else:
-            raise
+    else:
+        logger.warning(
+            "Dust bot '%s' not found in workspace; calling the webhook anyway", bot_name
+        )
 
-    client.chat_postMessage(
-        channel=channel_id,
-        text=_build_dust_message(bot_user_id, incident),
+    _call_dust_webhook(
+        webhook_url,
+        webhook_secret,
+        build_dust_message(incident, jira_postmortem.jira_issue_key),
     )
-    logger.info("Sent Dust post-mortem generation request for incident %s", incident_id)
+    logger.info(
+        "Called the Dust webhook for incident %s (post-mortem %s)",
+        incident_id,
+        jira_postmortem.jira_issue_key,
+    )

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from slack_sdk.errors import SlackApiError
 
@@ -9,6 +13,15 @@ from firefighter.incidents.factories import IncidentFactory, UserFactory
 from firefighter.jira_app.models import JiraPostMortem
 from firefighter.slack.factories import IncidentChannelFactory
 from firefighter.slack.tasks.generate_dust_postmortem import generate_dust_postmortem
+
+WEBHOOK_URL = "https://dust.example.com/webhooks/postmortem"
+WEBHOOK_SECRET = "s3cr3t"  # noqa: S105 - test fixture, not a real secret
+
+
+def _configure(settings) -> None:
+    settings.DUST_SLACK_BOT_NAME = "dust"
+    settings.DUST_WEBHOOK_URL = WEBHOOK_URL
+    settings.DUST_WEBHOOK_SECRET = WEBHOOK_SECRET
 
 
 def _make_incident_with_channel() -> object:
@@ -30,107 +43,174 @@ def _make_incident_without_channel() -> object:
     return incident
 
 
-@pytest.mark.django_db
-def test_invites_bot_and_posts_message(settings) -> None:
-    """Happy path: resolves bot user ID, invites bot then posts the generation request."""
-    settings.DUST_SLACK_BOT_NAME = "dust"
-    incident = _make_incident_with_channel()
-    channel_id = incident.conversation.channel_id
+def _with_postmortem(incident: object, key: str = "INCIDENT-27688") -> JiraPostMortem:
+    return JiraPostMortem.objects.create(
+        incident=incident, jira_issue_key=key, jira_issue_id="123456"
+    )
 
-    mock_client = MagicMock()
-    mock_client.conversations_invite.return_value = {"ok": True}
-    mock_client.chat_postMessage.return_value = {"ok": True}
+
+def _run(incident_id: int, slack_client: MagicMock) -> MagicMock:
+    """Run the task with the HTTP client mocked; returns the mocked client."""
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem.HttpClient"
+    ) as http_class:
+        http_client = http_class.return_value.__enter__.return_value
+        http_client.post.return_value = MagicMock(status_code=200)
+        generate_dust_postmortem(incident_id, client=slack_client)
+    return http_client
+
+
+def _slack_client() -> MagicMock:
+    client = MagicMock()
+    client.conversations_invite.return_value = {"ok": True}
+    return client
+
+
+@pytest.mark.django_db
+def test_calls_the_webhook_with_the_channel_and_the_ticket(settings) -> None:
+    _configure(settings)
+    incident = _make_incident_with_channel()
+    jira_pm = _with_postmortem(incident)
+    slack_client = _slack_client()
 
     with patch(
         "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
         return_value="UDUSTBOT1",
     ):
-        generate_dust_postmortem(incident.id, client=mock_client)
+        http_client = _run(incident.id, slack_client)
 
-    mock_client.conversations_invite.assert_called_once_with(
-        channel=channel_id, users=["UDUSTBOT1"]
+    slack_client.conversations_invite.assert_called_once_with(
+        channel=incident.conversation.channel_id, users=["UDUSTBOT1"]
     )
-    call_kwargs = mock_client.chat_postMessage.call_args.kwargs
-    assert call_kwargs["channel"] == channel_id
-    assert "UDUSTBOT1" in call_kwargs["text"]
-    assert "~IncidentManagementPostMortem" in call_kwargs["text"]
+    url, kwargs = http_client.post.call_args.args[0], http_client.post.call_args.kwargs
+    assert url == WEBHOOK_URL
+    message = json.loads(kwargs["content"])["message"]
+    assert jira_pm.jira_issue_key in message
+    assert incident.conversation.channel_id in message
+    # The instruction is no longer posted in Slack: the webhook is the trigger.
+    slack_client.chat_postMessage.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_message_includes_jira_postmortem_link(settings) -> None:
-    """When a Jira post-mortem exists, its link is embedded in the instruction."""
-    settings.DUST_SLACK_BOT_NAME = "dust"
+def test_signature_covers_the_exact_bytes_that_are_sent(settings) -> None:
+    """Signing a dict and letting the client re-serialize it would break the signature."""
+    _configure(settings)
     incident = _make_incident_with_channel()
-    jira_pm = JiraPostMortem.objects.create(
-        incident=incident,
-        jira_issue_key="INCIDENT-27688",
-        jira_issue_id="123456",
-    )
-
-    mock_client = MagicMock()
-    mock_client.conversations_invite.return_value = {"ok": True}
-    mock_client.chat_postMessage.return_value = {"ok": True}
+    _with_postmortem(incident)
 
     with patch(
         "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
         return_value="UDUSTBOT1",
     ):
-        generate_dust_postmortem(incident.id, client=mock_client)
+        http_client = _run(incident.id, _slack_client())
 
-    text = mock_client.chat_postMessage.call_args.kwargs["text"]
-    assert jira_pm.jira_issue_key in text
-    assert jira_pm.issue_url in text
-    assert "fill in the post-mortem" in text
+    kwargs = http_client.post.call_args.kwargs
+    body = kwargs["content"]
+    expected = hmac.new(
+        WEBHOOK_SECRET.encode("utf-8"), body, hashlib.sha256
+    ).hexdigest()
+    assert kwargs["headers"]["signature"] == f"sha256={expected}"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert isinstance(body, bytes)
 
 
 @pytest.mark.django_db
 def test_already_in_channel_is_tolerated(settings) -> None:
-    """If bot is already in channel, skip invite silently and still post message."""
-    settings.DUST_SLACK_BOT_NAME = "dust"
+    _configure(settings)
     incident = _make_incident_with_channel()
-
-    mock_client = MagicMock()
-    mock_client.conversations_invite.side_effect = SlackApiError(
+    _with_postmortem(incident)
+    slack_client = _slack_client()
+    slack_client.conversations_invite.side_effect = SlackApiError(
         "already_in_channel", {"ok": False, "error": "already_in_channel"}
     )
-    mock_client.chat_postMessage.return_value = {"ok": True}
 
     with patch(
         "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
         return_value="UDUSTBOT1",
     ):
-        generate_dust_postmortem(incident.id, client=mock_client)
+        http_client = _run(incident.id, slack_client)
 
-    mock_client.chat_postMessage.assert_called_once()
-
-
-@pytest.mark.django_db
-def test_skips_when_no_conversation(settings) -> None:
-    """If the incident has no Slack channel, do nothing."""
-    settings.DUST_SLACK_BOT_NAME = "dust"
-    incident = _make_incident_without_channel()
-
-    mock_client = MagicMock()
-
-    generate_dust_postmortem(incident.id, client=mock_client)
-
-    mock_client.conversations_invite.assert_not_called()
-    mock_client.chat_postMessage.assert_not_called()
+    http_client.post.assert_called_once()
 
 
 @pytest.mark.django_db
-def test_skips_when_bot_not_found(settings) -> None:
-    """If the Dust bot is not found in the workspace, do nothing."""
-    settings.DUST_SLACK_BOT_NAME = "dust"
+def test_missing_bot_does_not_stop_the_trigger(settings) -> None:
+    """The bot is only needed for the agent's reply; the webhook is what triggers it."""
+    _configure(settings)
     incident = _make_incident_with_channel()
-
-    mock_client = MagicMock()
+    _with_postmortem(incident)
+    slack_client = _slack_client()
 
     with patch(
         "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
         return_value=None,
     ):
-        generate_dust_postmortem(incident.id, client=mock_client)
+        http_client = _run(incident.id, slack_client)
 
-    mock_client.conversations_invite.assert_not_called()
-    mock_client.chat_postMessage.assert_not_called()
+    slack_client.conversations_invite.assert_not_called()
+    http_client.post.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_skips_when_no_conversation(settings) -> None:
+    _configure(settings)
+    incident = _make_incident_without_channel()
+    slack_client = _slack_client()
+
+    http_client = _run(incident.id, slack_client)
+
+    slack_client.conversations_invite.assert_not_called()
+    http_client.post.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_skips_when_the_incident_has_no_jira_postmortem(settings) -> None:
+    """There would be no ticket for the agent to fill in."""
+    _configure(settings)
+    incident = _make_incident_with_channel()
+
+    http_client = _run(incident.id, _slack_client())
+
+    http_client.post.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("missing", ["DUST_WEBHOOK_URL", "DUST_WEBHOOK_SECRET"])
+def test_skips_when_the_webhook_is_not_configured(settings, missing: str) -> None:
+    """An unsigned or targetless call would be rejected anyway."""
+    _configure(settings)
+    setattr(settings, missing, None)
+    incident = _make_incident_with_channel()
+    _with_postmortem(incident)
+
+    with patch(
+        "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+        return_value="UDUSTBOT1",
+    ):
+        http_client = _run(incident.id, _slack_client())
+
+    http_client.post.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_http_error_is_raised_so_celery_retries(settings) -> None:
+    _configure(settings)
+    incident = _make_incident_with_channel()
+    _with_postmortem(incident)
+
+    response = MagicMock()
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "boom", request=MagicMock(), response=MagicMock()
+    )
+    with (
+        patch(
+            "firefighter.slack.tasks.generate_dust_postmortem._resolve_bot_user_id",
+            return_value="UDUSTBOT1",
+        ),
+        patch(
+            "firefighter.slack.tasks.generate_dust_postmortem.HttpClient"
+        ) as http_class,
+    ):
+        http_class.return_value.__enter__.return_value.post.return_value = response
+        with pytest.raises(httpx.HTTPStatusError):
+            generate_dust_postmortem(incident.id, client=_slack_client())

--- a/tests/test_slack/test_generate_dust_postmortem_task.py
+++ b/tests/test_slack/test_generate_dust_postmortem_task.py
@@ -84,7 +84,14 @@ def test_calls_the_webhook_with_the_channel_and_the_ticket(settings) -> None:
     )
     url, kwargs = http_client.post.call_args.args[0], http_client.post.call_args.kwargs
     assert url == WEBHOOK_URL
-    message = json.loads(kwargs["content"])["message"]
+    payload = json.loads(kwargs["content"])
+    # Dust imposes no schema: the agent addresses the fields we choose to send,
+    # so the two values it needs are fields of their own, not prose to parse.
+    assert payload["jira_issue_key"] == jira_pm.jira_issue_key
+    assert payload["channel"]["id"] == incident.conversation.channel_id
+    assert payload["channel"]["name"] == incident.conversation.name
+    assert payload["incident"]["id"] == incident.id
+    message = payload["message"]
     assert jira_pm.jira_issue_key in message
     assert incident.conversation.channel_id in message
     # The instruction is no longer posted in Slack: the webhook is the trigger.


### PR DESCRIPTION
## Why

The "Generate post-mortem with Dust" button posted an instruction addressed to the Dust bot in the incident channel and relied on the agent noticing it. It does not work in practice. The Dust team exposes a webhook meant for this, so we call it instead.

## What the call looks like

```
POST <DUST_WEBHOOK_URL>
Content-Type: application/json
signature: sha256=<hmac-sha256 of the body, keyed with DUST_WEBHOOK_SECRET>

{
  "message": "Please fill in the post-mortem Jira ticket INCIDENT-27688 for incident #14923 (…). The incident was handled in the Slack channel #20260826-14923-prd-data-leak (C0BSXCGTDPE): read through it and complete the post-mortem…",
  "jira_issue_key": "INCIDENT-27688",
  "channel": {"id": "C0BSXCGTDPE", "name": "20260826-14923-prd-data-leak"},
  "incident": {"id": 14923, "title": "…"}
}
```

Dust imposes no payload schema — [its documentation](https://docs.dust.tt/docs/filter-webhooks-payload) says *"you define the structure based on your webhook source"*, and both the agent instructions and the webhook filters address fields by path (`issue.state`, `tags.*.name`). So the two values the agent needs are sent as fields it can address directly, and `message` carries the same instruction as prose.

The signature scheme is the one our inbound Jira webhooks already verify in `api.authentication`, used here in the outbound direction.

**The body is serialized once and posted as raw bytes.** Signing a dict and letting the HTTP client serialize it again would sign different bytes than the ones on the wire, and every call would be rejected — a test asserts the signature covers exactly what is sent.

The HTTP call goes through the existing `HttpClient` (timeouts and access logging already set), and `httpx.HTTPError` joins `SlackApiError` in the task's retry list.

## Behaviour changes worth reviewing

- **No Jira post-mortem, no call.** The agent's whole job is to fill that ticket in; there is nothing to write to without one. Previously a generic message was posted.
- **A missing Dust bot no longer aborts.** The bot is still invited to the channel — the agent answers there, and a non-member cannot post — but that is a nicety now, not the trigger.
- **Not configured is not an error.** Without both URL and secret the trigger is skipped with a warning rather than issuing a call the webhook would reject.

## To confirm with the Dust team before enabling

The payload is free-form on Dust's side, so nothing here can be rejected for its shape — but **the agent has to read the fields we send**. Worth a quick check that `IncidentManagementPostMortem` is configured to use `jira_issue_key` and `channel.id` (or the `message` text). Adding or renaming a field is a one-line change in `build_dust_payload`.

The signature is settled: Dust verifies an HMAC of the body, with the header name and algorithm chosen per webhook source ([docs](https://docs.dust.tt/docs/webhooks)) — `signature` and sha256 for ours, matching the screenshot from the webhook configuration page.

## Settings

| Name | Purpose |
| --- | --- |
| `DUST_WEBHOOK_URL` | the webhook to call |
| `DUST_WEBHOOK_SECRET` | shared secret used to sign the payload |

`ENABLE_DUST` and `DUST_SLACK_BOT_NAME` keep their current meaning. Documented in `docs/deploy/XX-settings.md`.

## Tests

Nine cases, replacing those that asserted the Slack message: signed payload contents, signature computed over the exact bytes, invite tolerated when already in channel, missing bot, missing channel, missing post-mortem, both missing-configuration cases, and an HTTP error propagating so Celery retries.
