### PR TITLE
docs(dust): document the webhook settings in the env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,3 +134,15 @@ FF_DEBUG_NO_SSO_REDIRECT=false
 # value must be set in the Atlassian webhook "Secret" field. Empty disables
 # the endpoints (fail-closed). Fed by Vault in non-local environments.
 RAID_JIRA_WEBHOOK_SECRET=""
+
+## Dust settings (optional) — AI generation of the Jira post-mortem
+ENABLE_DUST=True
+# Slack display name of the Dust app. Resolved at runtime to invite the bot to
+# the incident channel, so the agent can answer there.
+# DUST_SLACK_BOT_NAME=dust
+# Webhook that triggers the post-mortem agent, and the shared secret configured
+# on it. The payload is signed with HMAC-SHA256 and sent as the
+# `signature: sha256=<hex>` header. Both are required: without them the button
+# logs a warning and does nothing. Fed by Vault in non-local environments.
+DUST_WEBHOOK_URL=""
+DUST_WEBHOOK_SECRET=""


### PR DESCRIPTION
Follow-up to #367, which shipped the Dust webhook trigger but left its settings undocumented in the env example.

Adds the four Dust settings there: `ENABLE_DUST` and `DUST_SLACK_BOT_NAME`, which were never listed either, plus `DUST_WEBHOOK_URL` and `DUST_WEBHOOK_SECRET` introduced by #367. Without this, the only way to discover them is to read `settings/components/slack.py`.

Values are left empty: the real URL and secret are injected from Vault in non-local environments, as for `RAID_JIRA_WEBHOOK_SECRET`.

The commit was written on the #367 branch but landed after the squash merge, so it is cherry-picked onto `main` here.
